### PR TITLE
Calendar for all issues of newspaper

### DIFF
--- a/core/templates/includes/issue_frontpages_ctrl.html
+++ b/core/templates/includes/issue_frontpages_ctrl.html
@@ -1,7 +1,7 @@
 {% load static from staticfiles %}
 
 <div class="search_results_ctrl">
-    <span class="nav"><a href="{% url 'openoni_issues' issue.title.lccn %}" class="ar-back">Back to Browse All Available Issues</a> 
+    <span class="nav"><a href="{% url 'openoni_issues_title' issue.title.lccn %}" class="ar-back">Back to Browse All Available Issues</a> 
 | Show all front pages</span>
 {% if paginator.num_pages > 1 %}
     <span class="pagination">

--- a/core/templates/includes/issue_pages_ctrl.html
+++ b/core/templates/includes/issue_pages_ctrl.html
@@ -1,7 +1,7 @@
 {% load static from staticfiles %}
 
 <div class="search_results_ctrl">
-    <span class="nav"><a href="{% url 'openoni_issues' issue.title.lccn %}" class="ar-back">Back to Browse All Available Issues</a> 
+    <span class="nav"><a href="{% url 'openoni_issues_title' issue.title.lccn %}" class="ar-back">Back to Browse All Available Issues</a> 
 
 |
 {% if issue.previous %}

--- a/core/templates/issues.html
+++ b/core/templates/issues.html
@@ -1,4 +1,4 @@
-{% extends "newspaper.html" %}
+{% extends "site_base.html" %}
 
 {% block lc_metadata %}
 {% include "includes/lc_metadata.html" %}
@@ -9,8 +9,8 @@
 <script type="text/javascript">
 jQuery(function($){
     $("#id_year").change(function(){
-        window.location = '{% url 'openoni_issues' title.lccn %}' + this.value;        
-        });
+        window.location = '{% url 'openoni_issues' %}' + this.value;
+    });
     $("td.multiple").find("ul").css("display", "none");
     
     $("td.multiple").hover(
@@ -24,20 +24,25 @@ jQuery(function($){
 </script>
 {% endblock %}
 
-{% block extra_nav %}
-<div id="col2_left"> 
-    <form>
-        <label class="bold" for="year_select">Issues for:</label>&nbsp; {{select_year_form.year}}
-    </form>
-    
-    <p class="rule-top"><a href="{% url 'openoni_issues_first_pages' title.lccn %}"><strong>Show all front pages</strong></a></p> 
-    <p class="rule-top gray">Single edition:<br /> dates in <b>bold</b>.</p> 
-    <p class="gray">Multiple editions:<br /> dates in <b><i>bold italics</i></b>.</p> 
-</div><!-- end id:col2_left --> 
-{% endblock %}
+{% block subcontent %}
+    <div id="std_box"> 
+        {% block extra_nav %}
+            <div id="col2_left"> 
+                <form>
+                    <label class="bold" for="year_select">Issues for:</label>&nbsp; {{select_year_form.year}}
+                </form>
+                <p class="rule-top gray">Single edition:<br /> dates in <b>bold</b>.</p> 
+                <p class="gray">Multiple editions:<br /> dates in <b><i>bold italics</i></b>.</p> 
+            </div><!-- end id:col2_left --> 
+        {% endblock extra_nav %}
+        
+        {% block newspaper_content %}
+            <div id="col2_right" class='row'> 
+                {{year_view|safe}}
+            </div><!-- end id:col2_right --> 
+        {% endblock newspaper_content %}
 
-{% block newspaper_content %}
-<div id="col2_right" class='row'> 
-    {{year_view|safe}}
-</div><!-- end id:col2_right --> 
-{% endblock %}
+        <div class="clear"><!-- --></div> 
+    </div><!-- end id:std_box --> 
+{% endblock subcontent %}
+

--- a/core/templates/issues_title.html
+++ b/core/templates/issues_title.html
@@ -1,0 +1,43 @@
+{% extends "newspaper.html" %}
+
+{% block lc_metadata %}
+{% include "includes/lc_metadata.html" %}
+{% endblock %}
+
+{% block javascript %}
+{{ block.super }}
+<script type="text/javascript">
+jQuery(function($){
+    $("#id_year").change(function(){
+        window.location = '{% url 'openoni_issues_title' title.lccn %}' + this.value;
+    });
+    $("td.multiple").find("ul").css("display", "none");
+    
+    $("td.multiple").hover(
+    function () {
+    $(this).find("ul").slideToggle();
+    },
+    function () {
+    $(this).find("ul").slideToggle();
+    });
+});
+</script>
+{% endblock %}
+
+{% block extra_nav %}
+<div id="col2_left"> 
+    <form>
+        <label class="bold" for="year_select">Issues for:</label>&nbsp; {{select_year_form.year}}
+    </form>
+    
+    <p class="rule-top"><a href="{% url 'openoni_issues_first_pages' title.lccn %}"><strong>Show all front pages</strong></a></p> 
+    <p class="rule-top gray">Single edition:<br /> dates in <b>bold</b>.</p> 
+    <p class="gray">Multiple editions:<br /> dates in <b><i>bold italics</i></b>.</p> 
+</div><!-- end id:col2_left --> 
+{% endblock %}
+
+{% block newspaper_content %}
+<div id="col2_right" class='row'> 
+    {{year_view|safe}}
+</div><!-- end id:col2_right --> 
+{% endblock %}

--- a/core/templates/newspaper.html
+++ b/core/templates/newspaper.html
@@ -39,7 +39,7 @@
 
 {% block page_nav %} 
 <div id="page_nav">
-{% if title.has_issues %}<a id="page_nav_issues" href="{% url 'openoni_issues' title.lccn %}">Browse Issues</a> | {% endif %}
+{% if title.has_issues %}<a id="page_nav_issues" href="{% url 'openoni_issues_title' title.lccn %}">Browse Issues</a> | {% endif %}
 <a id="page_nav_title" href="{% url 'openoni_title' title.lccn %}">About</a> | <a id="page_nav_holdings" href="{% url 'openoni_title_holdings' title.lccn %}">Libraries that Have It</a> | <a id="page_nav_marc" href="{% url 'openoni_title_marc' title.lccn %}">MARC Record</a></div> 
 {% endblock %}
 

--- a/core/templates/newspapers.html
+++ b/core/templates/newspapers.html
@@ -40,7 +40,7 @@
             <tr>
                 <td class="first left_no_border"><a {% ifchanged state %}name="{{state}}" {% endifchanged %}href="{% url 'openoni_newspapers_state' state|pack_url %}">{{state}}</a></td>
                 <td><a href="{% url 'openoni_title' lccn %}"><strong>{{title.display_name}}</strong></a><br />{{title.place_of_publication}}, {{title.start_year}}-{{title.end_year}}</td>
-                <td><a href="{% url 'openoni_issues' lccn %}" shape="rect"><img src="{% static 'images/calendar_icon.gif' %}" alt="calendar"/></a></td>
+                <td><a href="{% url 'openoni_issues_title' lccn %}" shape="rect"><img src="{% static 'images/calendar_icon.gif' %}" alt="calendar"/></a></td>
                 <td>{{title.issues.count}}</td>
                 <td><a href="{% url 'openoni_issue_pages' lccn title.first 1 %}">{{title.first|date:'Y-m-d'}}</a></td>
                 <td><a href="{% url 'openoni_issue_pages' lccn title.last 1 %}">{{title.last|date:'Y-m-d'}}</a></td>

--- a/core/templates/newspapers.txt
+++ b/core/templates/newspapers.txt
@@ -1,4 +1,4 @@
 Persistent Link | State | Title | LCCN | OCLC | ISSN | No. of Issues | First Issue Date | Last Issue Date | More Info
 {% for state, titles in newspapers_by_state %}
-{% for title in titles %}http://{{host}}{% url 'openoni_issues' title.lccn %} | {{state}} | {{title}} | {{title.lccn|default:""}} | {{title.oclc|default:""}} | {{title.issn|default:""}} | {{title.issues.count}} | {{title.first}} | {{title.last}} | {% if title.has_essays %}http://{{host}}{% url 'openoni_title_essays' title.lccn %}{% endif %}
+{% for title in titles %}http://{{host}}{% url 'openoni_issues_title' title.lccn %} | {{state}} | {{title}} | {{title.lccn|default:""}} | {{title.oclc|default:""}} | {{title.issn|default:""}} | {{title.issues.count}} | {{title.first}} | {{title.last}} | {% if title.has_essays %}http://{{host}}{% url 'openoni_title_essays' title.lccn %}{% endif %}
 {% endfor %}{% endfor %}

--- a/core/templates/title.html
+++ b/core/templates/title.html
@@ -238,7 +238,7 @@
               <h3>{{title.display_name}}&nbsp;{{issue_date|date:"F j, Y"}}, Image {{title.first_issue.first_page.sequence}}</h3>
               <h4 class="browse">Browse:</h4>
             
-              <p><a href="{% url 'openoni_issues' lccn %}" class="view_cal">Calendar View</a></p>
+              <p><a href="{% url 'openoni_issues_title' lccn %}" class="view_cal">Calendar View</a></p>
               <p class="dot-top"><a href="{% url 'openoni_issues_first_pages' title.lccn %}">All front pages</a></p>
               {% if title.first_issue.first_page.sequence %}
               <p class="dot-top"><a href="{% url 'openoni_page' title.lccn title.first_issue.date_issued title.first_issue.edition title.first_issue.first_page.sequence %}">First Issue</a>

--- a/core/views/__init__.py
+++ b/core/views/__init__.py
@@ -1,7 +1,7 @@
 from search import search_pages_results, search_titles, \
      search_titles_opensearch,  search_pages_opensearch, suggest_titles
 
-from browse import issues, title_holdings, title_marc, \
+from browse import issues, issues_title, title_holdings, title_marc, \
     issues_first_pages, title_rdf, title_atom, title_marcxml, issue_pages, \
     page, title, titles, titles_in_city, titles_in_county, titles_in_state, \
     title_essays, page_ocr, page_pdf, page_jp2, page_ocr_xml, page_ocr_txt, \

--- a/core/views/directory.py
+++ b/core/views/directory.py
@@ -92,7 +92,7 @@ def newspapers(request, state=None, format='html'):
         for state, titles in newspapers_by_state:
             for title in titles:
                 writer.writerow(('http://%s%s' % (request.get_host(), 
-                                                  reverse('openoni_issues', 
+                                                  reverse('openoni_issues_title', 
                                                            kwargs={'lccn': title.lccn}),),
                                  state, title, title.lccn or '', title.oclc or '',
                                  title.issn or '', title.issues.count(), title.first, 

--- a/loc/templates/page.html
+++ b/loc/templates/page.html
@@ -166,7 +166,7 @@
           {% endif %}
           <strong>Issues</strong> 
           {% if next_issue_first_page %}
-          <a rel="next" href="{% url 'openoni_page' title.lccn next_issue_first_page.issue.date_issued next_issue_first_page.issue.edition next_issue_first_page.sequence %}"><img src="{% static 'images/item_btn_next.png' %}" width="17" height="17" alt="Next Issue" /></a><a class="all" href="{% url 'openoni_issues' title.lccn %}"><small>All Issues</small></a> 
+          <a rel="next" href="{% url 'openoni_page' title.lccn next_issue_first_page.issue.date_issued next_issue_first_page.issue.edition next_issue_first_page.sequence %}"><img src="{% static 'images/item_btn_next.png' %}" width="17" height="17" alt="Next Issue" /></a><a class="all" href="{% url 'openoni_issues_title' title.lccn %}"><small>All Issues</small></a> 
           {% endif %}
         </span>
         {% if page.jp2_filename %}

--- a/urls.py
+++ b/urls.py
@@ -97,12 +97,18 @@ urlpatterns += patterns(
     url(r'^lccn/(?P<lccn>\w+)/$', 'title', 
         name="openoni_title"),
 
+    # example: /issues/
+    url(r'^issues/$', 'issues', name="openoni_issues"),
+
+    # example: /issues/1900/
+    url(r'^issues/(?P<year>\d{4})/$', 'issues', name="openoni_issues_for_year"),
+
     # example: /lccn/sn85066387/issues/
-    url(r'^lccn/(?P<lccn>\w+)/issues/$', 'issues', name="openoni_issues"),
+    url(r'^lccn/(?P<lccn>\w+)/issues/$', 'issues_title', name="openoni_issues_title"),
 
     # example: /lccn/sn85066387/issues/1900
-    url(r'^lccn/(?P<lccn>\w+)/issues/(?P<year>\d{4})/$', 
-        'issues', name="openoni_issues_for_year"),
+    url(r'^lccn/(?P<lccn>\w+)/issues/(?P<year>\d{4})/$',
+       'issues_title', name="openoni_issues_title_for_year"),
 
     # example: /lccn/sn85066387/issues/first_pages
     url(r'^lccn/(?P<lccn>\w+)/issues/first_pages/$', 'issues_first_pages', 


### PR DESCRIPTION
Original "issues" now "issues_title" to reflect
that they are issues for a specific newspaper
Calendar generated in utils.py uses dropdown to display
the available titles on a given day
Address issue #29 