### PR TITLE
Feature/iiif fixes

### DIFF
--- a/conf/openoni.conf
+++ b/conf/openoni.conf
@@ -57,8 +57,8 @@ AliasMatch ^/(sitemap-\d+.xml)$ /opt/openoni/static/$1
 #CacheDirLevels 2
 
 # Change !RAIS_HOST! below to serve tiles and thumbnails from RAIS
-ProxyPass /images/tiles http://!RAIS_HOST!:12415/images/tiles
-ProxyPass /images/resize http://!RAIS_HOST!:12415/images/resize
+AllowEncodedSlashes NoDecode
+ProxyPass /images/iiif http://!RAIS_HOST!:12415/images/iiif nocanon
 
 #
 # Each directory to which Apache has access can be configured with respect

--- a/conf/openoni.conf
+++ b/conf/openoni.conf
@@ -60,6 +60,13 @@ AliasMatch ^/(sitemap-\d+.xml)$ /opt/openoni/static/$1
 AllowEncodedSlashes NoDecode
 ProxyPass /images/iiif http://!RAIS_HOST!:12415/images/iiif nocanon
 
+# Below is an example of splitting image servers for caching thumbnails.  Note
+# that (right now), RAIS requires that it listen on the same URL as what it
+# reports images using.
+#
+#ProxyPassMatch ^/images/resize/([^/]*)/full/([0-6][0-9][0-9],.*jpg)$ http://!RAIS_HOST!:12415/images/iiif/$1/full/$2 nocanon
+#ProxyPassMatch ^/images/iiif/(.*(jpg|info\.json))$ http://!RAIS_HOST!:12415/images/iiif/$1 nocanon
+
 #
 # Each directory to which Apache has access can be configured with respect
 # to which services and features are allowed and/or disabled in that

--- a/conf/openoni.ini
+++ b/conf/openoni.ini
@@ -19,8 +19,15 @@ PASSWORD=openoni
 URL=http://localhost:8983/solr
 
 ; Public URLs to the image server endpoints
+;
+; These must be overridden to point to the image server.  They may be set to
+; the same value, but they're kept apart to allow for having static thumbnails,
+; thumbnail caching separated from resize caching, etc.  Thumbnails are a much
+; smaller subset of possible images and therefore benefit a great deal from
+; being cached and/or pregenerated.
 [images]
-IIIF_SERVER=http://localhost/images/iiif
+RESIZE_SERVER=http://localhost/images/iiif
+TILE_SERVER=http://localhost/images/iiif
 
 ; Secrets go here.  SHHH!
 [secrets]

--- a/core/models.py
+++ b/core/models.py
@@ -20,7 +20,7 @@ from django.conf import settings
 from django.utils.http import urlquote
 
 from openoni.core.utils import strftime
-from openoni.core.utils.image_urls import thumb_image_url, tile_server_for_page
+from openoni.core.utils.image_urls import thumb_image_url, iiif_info_for_page
 
 from django.core import urlresolvers
 
@@ -646,10 +646,6 @@ class Page(models.Model):
     indexed = models.BooleanField(default=False)
     created = models.DateTimeField(auto_now_add=True)
 
-    @property
-    def iiif_id(self):
-        return settings.IIIF_SERVER + "/" + urlquote(self.relative_image_path, safe="")
-
     def json(self, host, serialize=True):
         j = {
             "thumbnail": thumb_image_url(self),
@@ -658,18 +654,18 @@ class Page(models.Model):
             "images": [{
                 "resource": {
                     "service": {
-                        "@id": tile_server_for_page(self),
+                        "@id": iiif_info_for_page(self),
                         "@context": "http://iiif.io/api/image/2/context.json",
                         "profile": "http://iiif.io/api/image/2/level0.json"
                     },
                     "format": "image/jpeg",
                     "height": self.jp2_length,
                     "width": self.jp2_width,
-                    "@id": tile_server_for_page(self),
+                    "@id": iiif_info_for_page(self),
                     "@type": "dctypes:Image"
                 },
                 "motivation": "sc:painting",
-                "@id": tile_server_for_page(self),
+                "@id": iiif_info_for_page(self),
                 "@type": "oa:Annotation",
                 "rendering": [
                     {"@id": "http://" + host + self.pdf_url, "format": "application/pdf"},
@@ -681,7 +677,7 @@ class Page(models.Model):
                 ]
             }],
             "label": str(self.sequence),
-            "@id": tile_server_for_page(self),
+            "@id": iiif_info_for_page(self),
             "@type": "sc:Canvas"
         }
 

--- a/core/static/js/page.js
+++ b/core/static/js/page.js
@@ -1,6 +1,5 @@
 (function($) {
     var page_url;
-    var tile_url;
     var coordinates_url;
     var navigation_url;
     var width;
@@ -105,7 +104,6 @@
 
     function initPage() {
         page_url = $('#page_data').data("page_url")
-        tile_url = $('#page_data').data("tile_url")
         coordinates_url = $('#page_data').data("coordinates_url")
         navigation_url = $('#page_data').data("navigation_url")
         width = $('#page_data').data("width")

--- a/core/templates/page.html
+++ b/core/templates/page.html
@@ -136,11 +136,10 @@
 
     <div id="page_data"
 	 data-static_url="{% static '' %}images/"
-   data-iiif_id="{% tile_server_for_page page %}"
+   data-iiif_id="{% iiif_info page %}"
 	 data-width="{{page.jp2_width}}"
 	 data-height="{{page.jp2_length}}"
 	 data-page_url="{% url 'openoni_page' title.lccn issue.date_issued issue.edition page.sequence %}"
-	 data-tile_url="{% tile_server_for_page page %}"
 	 data-coordinates_url="{% url 'openoni_page_coordinates' page.issue.title.lccn page.issue.date_issued page.issue.edition page.sequence %}"
 	 data-navigation_url="{% url 'openoni_search_pages_navigation' %}?"
 	 ></div>

--- a/core/templatetags/image_urls.py
+++ b/core/templatetags/image_urls.py
@@ -16,5 +16,5 @@ def specific_tile_url(page, w, h, x1, y1, x2, y2):
     return image_urls.specific_tile_url(page, w, h, x1, y1, x2, y2)
 
 @register.simple_tag
-def tile_server_for_page(page):
-    return image_urls.tile_server_for_page(page)
+def iiif_info(page):
+    return image_urls.iiif_info_for_page(page)

--- a/core/utils/image_urls.py
+++ b/core/utils/image_urls.py
@@ -3,14 +3,14 @@ from django.conf import settings
 from django.utils.http import urlquote
 
 def thumb_image_url(page):
-    return tile_server_for_page(page) + "/0,0,%s,%s/%s,/0/default.jpg" % (page.jp2_width, page.jp2_length, settings.THUMBNAIL_WIDTH)
+    return tile_server_for_page(page) + "/full/%d,/0/default.jpg" % settings.THUMBNAIL_WIDTH
 
 def medium_image_url(page):
-    return tile_server_for_page(page) + "/0,0,%s,%s/%s,/0/default.jpg" % (page.jp2_width, page.jp2_length, 550)
+    return tile_server_for_page(page) + "/full/550,/0/default.jpg"
 
 def specific_tile_url(page, w, h, x1, y1, x2, y2):
     x1, y1, x2, y2 = map(int, [x1, y1, x2, y2])
-    return tile_server_for_page(page) + "/%s,%s,%s,%s/%s,%s/0/default.jpg" % (x1, y1, x2-x1, y2-y1, w, h)
+    return tile_server_for_page(page) + "/%d,%d,%d,%d/%d,%d/0/default.jpg" % (x1, y1, x2-x1, y2-y1, w, h)
     
 def tile_server_for_page(page):
     return settings.IIIF_SERVER + "/" + urlquote(page.relative_image_path, safe="")

--- a/core/utils/image_urls.py
+++ b/core/utils/image_urls.py
@@ -1,16 +1,30 @@
 from django.conf import settings
-
 from django.utils.http import urlquote
 
+RESIZE = 0
+TILE = 1
+
 def thumb_image_url(page):
-    return tile_server_for_page(page) + "/full/%d,/0/default.jpg" % settings.THUMBNAIL_WIDTH
+    return resize_url(page, settings.THUMBNAIL_WIDTH)
 
 def medium_image_url(page):
-    return tile_server_for_page(page) + "/full/550,/0/default.jpg"
+    return resize_url(page, 550)
+
+def resize_url(page, size):
+    return  "%s/full/%d,/0/default.jpg" % (image_server_for_page(RESIZE, page), settings.THUMBNAIL_WIDTH)
 
 def specific_tile_url(page, w, h, x1, y1, x2, y2):
     x1, y1, x2, y2 = map(int, [x1, y1, x2, y2])
-    return tile_server_for_page(page) + "/%d,%d,%d,%d/%d,%d/0/default.jpg" % (x1, y1, x2-x1, y2-y1, w, h)
-    
-def tile_server_for_page(page):
-    return settings.IIIF_SERVER + "/" + urlquote(page.relative_image_path, safe="")
+    return "%s/%d,%d,%d,%d/%d,%d/0/default.jpg" % (image_server_for_page(TILE, page), x1, y1, x2-x1, y2-y1, w, h)
+
+def image_server_for_page(server_type, page):
+    server = ""
+    if server_type == RESIZE:
+        server = settings.RESIZE_SERVER
+    if server_type == TILE:
+        server = settings.TILE_SERVER
+
+    return "%s/%s" % (server, urlquote(page.relative_image_path, safe=""))
+
+def iiif_info_for_page(page):
+    return "%s/info.json" % (image_server_for_page(TILE, page))

--- a/core/utils/image_urls.py
+++ b/core/utils/image_urls.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.utils.http import urlquote
 
+# Enums / constants for telling image_server_for_page which URL prefix to use
 RESIZE = 0
 TILE = 1
 

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -20,7 +20,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
   python-virtualenv \
   supervisor
 
-RUN a2enmod cache expires rewrite proxy_http
+RUN a2enmod cache cache_disk expires rewrite proxy_http
+RUN mkdir -p /var/cache/httpd/mod_disk_cache
+RUN chown -R www-data:www-data /var/cache/httpd
 ADD apache/openoni.conf /etc/apache2/sites-available/openoni-orig.conf
 RUN a2dissite 000-default.conf
 

--- a/docker/apache/openoni.conf
+++ b/docker/apache/openoni.conf
@@ -43,22 +43,23 @@ AliasMatch ^/robots.txt$ /opt/openoni/static/robots.txt
 AliasMatch ^/sitemap.xml$ /opt/openoni/static/sitemap.xml
 AliasMatch ^/(sitemap-\d+.xml)$ /opt/openoni/static/$1
 
-# Uncomment below to cache thumbnails (and only thumbnails)
-#CacheRoot /var/cache/httpd/mod_disk_cache
-#CacheEnable disk /images/resize
-#
-## Allow a total of 4096 content directories at two levels so we never have
-## more than 64 directories in any other directory.  If we cache a million
-## thumbnails, we'll still only end up with about 250 files per content
-## directory.
-##
-## If we start caching tiles, this will need to change a lot.
-#CacheDirLength 1
-#CacheDirLevels 2
+# Cache thumbnails (and only thumbnails)
+CacheRoot /var/cache/httpd/mod_disk_cache
+CacheEnable disk /images/resize
+
+# Allow a total of 4096 content directories at two levels so we never have
+# more than 64 directories in any other directory.  If we cache a million
+# thumbnails, we'll still only end up with about 250 files per content
+# directory.
+CacheDirLength 1
+CacheDirLevels 2
+
+LogLevel debug
 
 # Change !RAIS_HOST! below to serve tiles and thumbnails from RAIS
 AllowEncodedSlashes NoDecode
-ProxyPass /images/iiif http://!RAIS_HOST!:12415/images/iiif nocanon
+ProxyPassMatch ^/images/resize/([^/]*)/full/([0-6][0-9][0-9],.*)$ http://!RAIS_HOST!:12415/images/iiif/$1/full/$2 nocanon
+ProxyPassMatch ^/images/iiif/(.*)$ http://!RAIS_HOST!:12415/images/iiif/$1 nocanon
 
 #
 # Each directory to which Apache has access can be configured with respect

--- a/docker/apache/openoni.conf
+++ b/docker/apache/openoni.conf
@@ -58,8 +58,8 @@ LogLevel debug
 
 # Change !RAIS_HOST! below to serve tiles and thumbnails from RAIS
 AllowEncodedSlashes NoDecode
-ProxyPassMatch ^/images/resize/([^/]*)/full/([0-6][0-9][0-9],.*)$ http://!RAIS_HOST!:12415/images/iiif/$1/full/$2 nocanon
-ProxyPassMatch ^/images/iiif/(.*)$ http://!RAIS_HOST!:12415/images/iiif/$1 nocanon
+ProxyPassMatch ^/images/resize/([^/]*)/full/([0-6][0-9][0-9],.*jpg)$ http://!RAIS_HOST!:12415/images/iiif/$1/full/$2 nocanon
+ProxyPassMatch ^/images/iiif/(.*(jpg|info\.json))$ http://!RAIS_HOST!:12415/images/iiif/$1 nocanon
 
 #
 # Each directory to which Apache has access can be configured with respect

--- a/docker/openoni.ini
+++ b/docker/openoni.ini
@@ -12,7 +12,8 @@ PASSWORD=openoni
 URL=http://!SOLR_HOST!:8983/solr
 
 [images]
-IIIF_SERVER=!APP_URL!/images/iiif
+RESIZE_SERVER=!APP_URL!/images/resize
+TILE_SERVER=!APP_URL!/images/iiif
 
 ; Secrets go here.  SHHH!
 [secrets]

--- a/settings.py
+++ b/settings.py
@@ -14,9 +14,11 @@ def override_solr(conf):
     SOLR = conf.get("solr", "URL")
 
 def override_image_server(conf):
-  global IIIF_SERVER
-  if conf.has_option("images", "IIIF_SERVER"):
-    IIIF_SERVER = conf.get("images", "IIIF_SERVER")
+  global RESIZE_SERVER, TILE_SERVER
+  if conf.has_option("images", "RESIZE_SERVER"):
+    RESIZE_SERVER = conf.get("images", "RESIZE_SERVER")
+  if conf.has_option("images", "TILE_SERVER"):
+    TILE_SERVER = conf.get("images", "TILE_SERVER")
 
 def override_secrets(conf):
   global SECRET_KEY

--- a/settings_base.py
+++ b/settings_base.py
@@ -143,8 +143,15 @@ BROKER_TRANSPORT = "django"
 # should also make this overrideable in the INI file.
 IS_PRODUCTION = False
 
-# These must be overridden to point to the image server
-IIIF_SERVER = "http://example.com/images/iiif"
+# Public URLs to the image server endpoints
+#
+# These must be overridden to point to the image server.  They may be set to
+# the same value, but they're kept apart to allow for having static thumbnails,
+# thumbnail caching separated from resize caching, etc.  Thumbnails are a much
+# smaller subset of possible images and therefore benefit a great deal from
+# being cached and/or pregenerated.
+RESIZE_SERVER = "http://example.com/images/iiif"
+TILE_SERVER = "http://example.com/images/iiif"
 
 # How big should thumbnails be?
 THUMBNAIL_WIDTH = 240


### PR DESCRIPTION
Fixes #129 

Splits up thumbnail URL from tile URL for IIIF.  The two default to being the same, but having them as separate settings gives us the option to make thumbnails more static while keeping the rest of the dynamic IIIF image tiling.  (e.g., pregenerating thumbnails and/or caching at the apache level)