### PR TITLE
Make Apache logs available to `docker logs`

### DIFF
--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -20,6 +20,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
   python-virtualenv \
   supervisor
 
+# Force apache error logs to stderr
+RUN ln -sf /proc/self/fd/1 /var/log/apache2/error.log
+
 RUN a2enmod cache cache_disk expires rewrite proxy_http
 RUN mkdir -p /var/cache/httpd/mod_disk_cache
 RUN chown -R www-data:www-data /var/cache/httpd


### PR DESCRIPTION
`docker logs openoni-dev` is now pleasant and useful