### PR TITLE
Feature/customizable name

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -11,7 +11,8 @@ def extra_request_info(request):
     """
     fulltext_range = _fulltext_range()
     return {
-        'site_title': 'Chronicling America',
+        'site_title': settings.SITE_TITLE if "SITE_TITLE" in dir(settings) else None,
+        'project_name': settings.PROJECT_NAME if "PROJECT_NAME" in dir(settings) else None,
         'omniture_url': settings.OMNITURE_SCRIPT if "OMNITURE_SCRIPT" in dir(settings) else None,
         'sharetool_url': settings.SHARETOOL_URL if "SHARETOOL_URL" in dir(settings) else None,
         'fulltext_startdate': fulltext_range[0],

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -18,15 +18,14 @@ class TooBusyMiddleware(object):
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Server Too Busy - Chronicling America - Chronicling America (The Library of Congress)</title> 
+  <title>Server Too Busy</title> 
   <style></style>
 </head>
 <body>
      <article>
 	  <h1>Server Too Busy</h1>
 	   <div>
-            <p>The Chronicling America server is currently too busy to serve your request. Please try your request again shortly.</p>
-            <p><a href="http://www.loc.gov/pictures/resource/ppmsc.01752/"><img src="http://lcweb2.loc.gov/service/pnp/ppmsc/01700/01752r.jpg"/></a></p>
+            <p>Please try your request again shortly.</p>
 	   </div>
      </article>
 </body>

--- a/core/models.py
+++ b/core/models.py
@@ -1126,9 +1126,9 @@ class Country(models.Model):
     A model for capturing MARC country codes found at:
     http://www.loc.gov/marc/countries/
 
-    It's used primarily for state information since Chronicling America
-    is about the United States and the MARC country codes contains
-    distinct codes for each US state. Go figure.
+    It's used primarily for state information since the original
+    Chronicling American project is about the United States and 
+    the MARC country codes contains distinct codes for each US state.
     """
     code = models.CharField(null=False, max_length=3, primary_key=True)
     name = models.CharField(null=False, max_length=100)

--- a/core/templates/500.html
+++ b/core/templates/500.html
@@ -10,7 +10,7 @@
 {% block subcontent %}
 <div id="box_right">
     <div style="margin: 10px;">
-    Chronicling America has encountered an unexpected error while
+    {{ site_title }} has encountered an unexpected error while
     processing your request. The details of this error have been
     logged, and our troubleshooting specialists will be notified. We
     apologize for any inconvenience.

--- a/core/templates/about.html
+++ b/core/templates/about.html
@@ -7,8 +7,7 @@
 
 {% block main_content %}
  <div id="std_box">
-  <!--div class="about_pic_box"><a href="#"><img src="images/logo_neh.gif" width="210" height="101" alt="neh" /></a><br /><a href="#"><img class="loc" src="images/logo_loc.gif" width="215" height="47" alt="Library of Congress" /></a></div-->
-  <h3><a id="about Open ONI" shape="rect">About Open ONI</a></h3>
+  <h3><a id="about" shape="rect">About Open ONI</a></h3>
   <p>The Open Online Newspaper Initiative (Open ONI) is a collaborative, open-source software platform for providing online access to digital newspaper content. An extension of the LC Newspaper Viewer (chronam) software developed by the Library of Congress for the National Digital Newspaper Program (NDNP), a partnership between the National Endowment for the Humanities (NEH) and the Library of Congress (LC), Open ONI strives to provide an accessible platform for states and local organizations to make keyword-searchable digital newspaper content freely available to the public online. Supported by a community of heritage institutions across the United States, this rich digital resource will be developed and permanently maintained by contributors and users within the community. Contributor institutions include the University of Oregon, University of Nebraska-Lincoln, Pennsylvania State University, University of South Carolina, Paul Smith's College, LYRASIS, Northern New York Library Network, Digital Public Library of America, Stanford University, and the North Carolina Digital Heritage Center.</p> 
   
   <p>Open ONI is designed to work with newspaper materials digitized to technical specifications set by the Library of Congress. These specifications include the following basic elements (profiles describing the full set of specifications can be found at <a href="http://www.loc.gov/ndnp/guidelines/" shape="rect">http://www.loc.gov/ndnp/guidelines/</a>) : </p>

--- a/core/templates/help.html
+++ b/core/templates/help.html
@@ -11,54 +11,35 @@
     <ul>
         <li class="down"><a href="#faq" shape="rect">FAQs</a></li>
         <li class="down"><a href="#how_to_view" shape="rect">How to View</a> </li>
-        <li class="down"><a href="#basic_searching" shape="rect">Basic Searching in <em>Chronicling America</em></a> </li>
-        <li class="down"><a href="#advanced_searching" shape="rect">Advanced Searching in <em>Chronicling America</em></a> </li>
+        <li class="down"><a href="#basic_searching" shape="rect">Basic Searching in <em>{{ site_title }}</em></a> </li>
+        <li class="down"><a href="#advanced_searching" shape="rect">Advanced Searching in <em>{{ site_title }}</em></a> </li>
         <li class="down"><a href="#search_and_browsing_tips" shape="rect">Search and Browsing Tips</a> </li>
-        <li class="down"><a href="#language_searching" shape="rect">Searching by Language in <em>Chronicling America</em></a> </li>
-        <li class="down"><a href="#searching_directory" shape="rect">Searching the U.S. Newspaper Directory 1690-Present</a> </li>
+        <li class="down"><a href="#language_searching" shape="rect">Searching by Language</a> </li>
     </ul>
 
 <br />
 
 <h2 id="faq">Frequently Asked Questions (FAQs)</h2>
 
-<h4>What is the U.S. Newspaper Directory?</h4>
-<p>The U.S. Newspaper Directory is derived from the library catalog records created by state institutions during the NEH-sponsored <a href="http://www.neh.gov/us-newspaper-program">United States Newspaper Program</a>, 1980-2011. This program funded state-level projects to locate, describe (catalog), and selectively preserve (via treatment and microfilm) historic newspaper collections in that state, published from 1690 to the present. Under this program, each institution created machine-readable cataloging (MARC) records via the Cooperative ONline SERials Program (CONSER) for its state collections, contributing bibliographic descriptions and library holdings information to the Newspaper Union List, now included in WorldCat and hosted by the Online Computer Library Center (OCLC). This data, approximately 150,000 bibliographic title entries and hundreds of thousands of library holdings records, was acquired and converted to MARCXML format for use in the  <em>Chronicling America</em> U.S. Newspaper Directory.</p>
-
-<h4>Why are there pages from only certain states?</h4>
-<p><em>Chronicling America</em> is sponsored by the National Digital Newspaper Program (NDNP).  This program, funded by the National Endowment for the Humanties (NEH), awards money to public newspaper archives in each state to digitize and deliver historic newspaper content to the Library of Congress for inclusion in <em>Chronicling America</em>.  Cultural heritage institutions within the states apply for the NEH grants.  For information on what states are contributing digitized newspapers to the program, see the <a href="http://www.loc.gov/ndnp/awards/">NDNP Award Recipients</a>*. Eventually, the NEH will fund awards in every state and territory.</p>
-<p>** The Library of Congress contributes digitized content from Washington, DC (1836-1922) and other significant material.</p>
-<p>Note: Awardees may select papers to digitize within the time period eligibility of their award. All periods may not be selected or available at this time, but content representing these states and time periods may be scheduled to be added in future updates. Additionally, due to copyright restrictions the collection does not include newspapers published after December 31, 1922.</p>
-
-<h4>When will more pages be available?</h4>
-<p><em>Chronicling America</em> is updated regularly with additional content received from awardees. NEH hosts an NDNP annual award competition, gradually increasing the content time period and the geographic representation through additional awards.</p>
-
 <h4>Why does the View Text link on the full Page screen show misspellings and badly-formed words?</h4>
-<p>The View Text option in <em>Chronicling America</em> displays machine-generated text that is produced by Optical Character Recognition (OCR) software. OCR is a fully automated process that converts the visual image of numbers and letters into computer-readable numbers and letters. Computer software can then search the OCR-generated text for words, phrases, numbers, or other characters. However, OCR is not 100 percent accurate, and, particularly if the original item has extraneous markings on the page, unusual text styles, or very small fonts, the searchable text OCR generates will contain errors that cannot be corrected by automated means. Digitization of microfilmed newspapers inherently includes a wide range of image quality in the content (quality derived from the original newspaper, the original newspaper when it was microfilmed and associated deterioration, or the film itself.)</p>
+<p>The View Text option in <em>{{ site_title }}</em> displays machine-generated text that is produced by Optical Character Recognition (OCR) software. OCR is a fully automated process that converts the visual image of numbers and letters into computer-readable numbers and letters. Computer software can then search the OCR-generated text for words, phrases, numbers, or other characters. However, OCR is not 100 percent accurate, and, particularly if the original item has extraneous markings on the page, unusual text styles, or very small fonts, the searchable text OCR generates will contain errors that cannot be corrected by automated means. Digitization of microfilmed newspapers inherently includes a wide range of image quality in the content (quality derived from the original newspaper, the original newspaper when it was microfilmed and associated deterioration, or the film itself.)</p>
 <p>Although errors in the process are unavoidable, OCR is still a powerful tool for making text-based items accessible to searching. For example, important concept words often appear more than once within an article. Therefore, if OCR misreads one instance of a key word in a passage, but correctly reads the second instance, the passage will still be found in a full-text search.</p>
-
-<h4>Why are there variant spellings of counties and cities in the Newspaper Directory Search?</h4>
-<p>The Newspaper Directory data is loaded dynamically from the <em>Chronicling America</em> directory records. Misspellings in place names are the result of typographical errors in the CONSER records and can only be corrected in the original CONSER records hosted by OCLC WorldCat. Please contact a CONSER member <a href="http://www.loc.gov/acq/conser/conmembs.html" shape="rect">(http://www.loc.gov/acq/conser/conmembs.html)</a> with library holdings of that title to request cataloging improvements to these records.</p>
 
 <h4>Why do diacritics and non-English language characters sometimes appear &quot;Romanized&quot; or not in their original alphabets?</h4>
 <p>The Newspaper Directory provides access to newspaper title records cataloged according to standard bibliographic rules. Until recently, most non-English language characters were difficult to represent in library records and so Romanization - or standard rules for transliterating other alphabets to the Roman alphabet - was used to convey phonetic pronunciations of non-English words.</p>
 
-<h4>I&#39;ve discovered a Directory newspaper title record in need of updating or editing, what should I do?</h4>
-<p>Newspaper title information included in <em>Chronicling America</em> is downloaded at regular intervals from the CONSER (Cooperative Online Serials Cataloging) database, made available through OCLC WorldCat. In order to update or edit these records in <em>Chronicling America</em>, please contact a CONSER member <a href="http://www.loc.gov/acq/conser/conmembs.html" shape="rect">(http://www.loc.gov/acq/conser/conmembs.html)</a> with library holdings of that title to request cataloging improvements to the original
-CONSER/WorldCat records.</p>
-
-<h4>How do I cite or reference newspaper Directory records and pages for re-use (e.g., in a Web site or other electronic display) or reference (e.g., in a bibliography or journal article) external to <em>Chronicling America</em>?</h4>
-<p><em>Chronicling America</em> supports persistent links to newspaper Directory records and pages by providing a predictable URL, displayed in the descriptive information for that object. Using the proposed <a href="http://bitworking.org/projects/URI-Templates/draft-gregorio-uritemplate-00.html" onmouseup="return linkDisclaimer.rewriteAnchor(this);" shape="rect">URI Template</a> syntax the links will use the pattern:   </p>
-<ul><li>http://chroniclingamerica.loc.gov/lccn/{lccn}/{date}/ed-{edition}/seq-{image sequence}</li></ul>
+<h4>How do I cite or reference newspaper Directory records and pages for re-use (e.g., in a Web site or other electronic display) or reference (e.g., in a bibliography or journal article)?</h4>
+<p><em>{{ site_title }}</em> supports persistent links to newspaper directory records and pages by providing a predictable URL, displayed in the descriptive information for that object. Using the proposed <a href="http://bitworking.org/projects/URI-Templates/draft-gregorio-uritemplate-00.html" onmouseup="return linkDisclaimer.rewriteAnchor(this);" shape="rect">URI Template</a> syntax the links will use the pattern:   </p>
+<ul><li>{{ BASE_URL }}/lccn/{lccn}/{date}/ed-{edition}/seq-{image sequence}</li></ul>
 <p>Where:</p>
 <ul><li><em>lccn</em> is the # Library of Congress Control Number for the newspaper</li><li><em>date</em> is the date of the issue, specified as yyyy-mm-dd (e.g. 1902-01-30)</li><li><em>edition</em> is the edition number for that date (e.g. 1)</li><li><em>seq</em> is the image sequence number (e.g. 23) for that issue.</li></ul>
 <p>For example:</p>  
-<ul><li>http://chroniclingamerica.loc.gov/lccn/sn84026749/1903-01-08/ed-1/seq-2</li></ul>
-<p>When describing <em>Chronicling America</em> as the source of content, please use the URL and a Web site citation, such as &quot;from the Library of Congress, <em>Chronicling America</em>: Historic American Newspapers site&quot;.</p>
+<ul><li>{{ BASE_URL }}/lccn/sn84026749/1903-01-08/ed-1/seq-2</li></ul>
+<p>When describing <em>{{ site_title }}</em> as the source of content, please use the URL and a website citation, such as &quot;from <em>{{ project_name }}</em>&quot;.</p>
 <br />
 
 <h2 id="how_to_view">How to View</h2>
-<p>Images of historic newspaper pages, as well as uncorrected page text, are displayed through your web browser.  However, <em>Chronicling America</em> also contains high-resolution images (JPEG2000) and enhanced text (PDF) that may require special viewers. Most viewers can be downloaded free from vendor sites. The links below explain the various formats used and how to access them.</p>
+<p>Images of historic newspaper pages, as well as uncorrected page text, are displayed through your web browser.  However, <em>{{ site_title }}</em> also contains high-resolution images (JPEG2000) and enhanced text (PDF) that may require special viewers. Most viewers can be downloaded free from vendor sites. The links below explain the various formats used and how to access them.</p>
 
 <h3>Download and View Pages Offline</h3>
 <table class="table table-bordered" summary="table summarizing document formats, including viewers and samples" cellspacing="0" class="std full">
@@ -76,7 +57,7 @@ CONSER/WorldCat records.</p>
         <td rowspan="1" colspan="1">Windows:<br/>
             - <a href="http://www.erdas.com/products/ERDASERMapper/ERDASERViewer/Details.aspx" onmouseup="return linkDisclaimer.rewriteAnchor(this);" shape="rect">ERDAS ER Viewer</a><br/>
             - <a href="http://www.kakadusoftware.com" onmouseup="return linkDisclaimer.rewriteAnchor(this);" shape="rect">Kdu_show</a><br/>
-            - <a href="http://www.irfanview.com" onmouseup="return linkDisclaimer.rewriteAnchor(this);" shape="rect">IrfanView with JPEG2000 plug-in</a><br/><br/>OS X:Preview supports baseline JP2 only; commercial software may be needed to view tiled JP2 files, such as those in <em>Chronicling America</em>.</td>
+            - <a href="http://www.irfanview.com" onmouseup="return linkDisclaimer.rewriteAnchor(this);" shape="rect">IrfanView with JPEG2000 plug-in</a><br/><br/>OS X:Preview supports baseline JP2 only; commercial software may be needed to view tiled JP2 files, such as those in <em>{{ site_title }}</em>.</td>
         <td rowspan="1" colspan="1">
             - <a href="http://chroniclingamerica.loc.gov/lccn/sn84024441/1901-12-16/ed-1/seq-1.jp2" shape="rect">Sample JPEG2000 page</a><br/>
             - <a href="http://chroniclingamerica.loc.gov/lccn/sn84024441/1901-12-16/ed-1/seq-1" shape="rect">About this sample</a></td>
@@ -85,16 +66,16 @@ CONSER/WorldCat records.</p>
 <p>Some Web browsers incorrectly assume that Quicktime (automatically included with the browser software) can display a JPEG2000 image (JPEG2000, or .jp2, is not a &quot;native&quot; Web format.) To counteract this effect, download the JPEG2000 (JP2) image by &quot;right-click*quot;-ing with the mouse on the image link --e.g., &quot;JP2 (4.0 Mb)&quot;. In the dialog box that appears, you will see &quot;Save Link As...&quot; or &quot;Save Target As...&quot; (depending on the Web browser used). Selecting this option will result in downloading the image to your desktop for further review.</p>
 <p>To view the JPEG2000 (.jp2) file you will need a JPEG2000-friendly software, such as those listed above.</p><br/>
 
-<h2 id="basic_searching">Basic Searching in Chronicling America</h2>
-<p><em>Chronicling America</em> provides access to historic newspaper pages digitized under the NEH/LC National Digital Newspaper Program (NDNP). For more information on the scope and content of the program, click here <a href="http://www.neh.gov/projects/ndnp.html" shape="rect">(http://www.neh.gov/projects/ndnp.html).</a></p>
-<p>Search <em>Chronicling America</em> to find</p>
+<h2 id="basic_searching">Basic Searching in {{ site_title }}</h2>
+<p><em>{{ site_title }}</em> provides access to historic newspaper pages digitized under the NEH/LC National Digital Newspaper Program (NDNP). For more information on the scope and content of the program, click here <a href="http://www.neh.gov/projects/ndnp.html" shape="rect">(http://www.neh.gov/projects/ndnp.html).</a></p>
+<p>Search <em>{{ site_title }}</em> to find</p>
 <ul>
     <li>information on persons, places, or events;</li>
     <li>specific topics or news of the day;</li>
     <li>concepts or ideas;</li>
     <li>unique passages of text, such as the source of a frequently-quoted phrase.</li>
 </ul>
-<p>Users of <em>Chronicling America</em> have the option of performing basic or advanced searches.  The basic search box is designated as the blue <em>Search Pages</em> tab and is found on many of the pages of the site. Basic search options are limited to state, time period, and key words located near each other.  The basic search returns all supported languages. </p>
+<p>Users of <em>{{ site_title }}</em> have the option of performing basic or advanced searches.  The basic search box is designated as the blue <em>Search Pages</em> tab and is found on many of the pages of the site. Basic search options are limited to state, time period, and key words located near each other.  The basic search returns all supported languages. </p>
 <p>For basic searches, results listed first are most likely to be relevant to your search. Results will appear higher in the list when they contain</p>
 <ul>
     <li>exact matches of your search terms;</li>
@@ -110,14 +91,14 @@ CONSER/WorldCat records.</p>
     <li>Diacritic characters (accent marks, in non-English text) and other special characters produce inaccurate results, so plain (unaccented) letters should be substituted for letters with diacritics.</li>
 </ul>
 
-<p><em>Chronicling America</em>&#39;s search engine utilizes language-specific dictionaries toinclude word variants for your search terms.  This is often called stemming.  For example, the search term <b>house</b>, when stemmed in English, would also return words like <b>houses</b> and <b>housing</b>.  </p>
-<p>For more search options, see Advanced Searching in <em>Chronicling America</em> below.  For information about language support in <em>Chronicling America</em>, see Searching by Language in <em>Chronicling America</em>.</p>
+<p><em>{{ site_title }}</em>&#39;s search engine utilizes language-specific dictionaries toinclude word variants for your search terms.  This is often called stemming.  For example, the search term <b>house</b>, when stemmed in English, would also return words like <b>houses</b> and <b>housing</b>.  </p>
+<p>For more search options, see Advanced Searching in <em>{{ site_title }}</em> below.  For information about language support in <em>{{ site_title }}</em>, see Searching by Language in <em>{{ site_title }}</em>.</p>
 
-<h2 id="advanced_searching">Advanced Searching in Chronicling America</h2>
+<h2 id="advanced_searching">Advanced Searching in {{ site_title }}</h2>
 <p>To make the most of searching this text, take advantage of the search options provided on the Search page.</p>
 <ul>
     <li>To limit your search to particular geographic area, select one or more States.</li>
-    <li>Or, you can limit your search to a particular newspaper, or select several newspapers, picked from the list of titles currently available in <em>Chronicling America</em>.</li>
+    <li>Or, you can limit your search to a particular newspaper, or select several newspapers, picked from the list of titles currently available in <em>{{ site_title }}</em>.</li>
     <li>In addition or alternatively, you can search the entire date range available (default), or select a specific date and limit your search to a specific year, month, or even day, using the begin date and end date lists provided. (Note: selecting the same begin month/day/year and end month/day/year will provide links to every page available for that specific date.)</li>
     <li>In addition or alternatively, enter a specific search term or terms in the Keyword boxes provided. The operators provided will influence the results of your search significantly and can be used in separate searches or in conjunction within a single search.</li>
 </ul>
@@ -163,72 +144,30 @@ CONSER/WorldCat records.</p>
 
 <h2 id="search_and_browsing_tips">Search and Browsing Tips</h2>
 <ul>
-    <li>Many browsers have the capability of tabbed browsing, which opens a new pane in the current window, either in the background or the foreground. Users of Chronicling America have reported this as a useful method of navigating through search results- bringing up each result in a new tab. This may be accomplished by clicking with the right-hand mouse button (for Mac, hold down the Command key) and selecting &quot;Open Link in New Tab.&quot; </li>
-    <li>Search results are displayed on a page that can easily be bookmarked or navigated to via the &quot;Back&quot; button on the browser. Every page in the <em>Chronicling America</em> application can be bookmarked, but only the addresses containing newspaper pages should be treated as canonical for purposes of citations and long-term referrals.  These addresses are displayed in the address bar of the browser, and no special treatment is required for adding them to a citation database. (Select the &quot;Persistent Link&quot; URL displayed on each newspaper page view to store the link without search text highlighted.)</li>
+    <li>Many browsers have the capability of tabbed browsing, which opens a new pane in the current window, either in the background or the foreground. Users of {{ site_title }} have reported this as a useful method of navigating through search results- bringing up each result in a new tab. This may be accomplished by clicking with the right-hand mouse button (for Mac, hold down the Command key) and selecting &quot;Open Link in New Tab.&quot; </li>
+    <li>Search results are displayed on a page that can easily be bookmarked or navigated to via the &quot;Back&quot; button on the browser. Every page in the <em>{{ site_title }}</em> application can be bookmarked, but only the addresses containing newspaper pages should be treated as canonical for purposes of citations and long-term referrals.  These addresses are displayed in the address bar of the browser, and no special treatment is required for adding them to a citation database. (Select the &quot;Persistent Link&quot; URL displayed on each newspaper page view to store the link without search text highlighted.)</li>
 
     <li>All pages are digitally scanned - primarily from microfilm, described, and automatically processed for full-text searching through a process called Optical Character Recognition (OCR). This text is organized in normal reading order (by column) and left uncorrected. Search strategies may take this into consideration (i.e., searching for shorter words and phrases when possible in order to maximize the number of search results returned).</li>
     <li>One helpful way to use the full-text search feature is to enter a term or phrase containing many words that characterize the topic you wish to investigate. A full-text search will then retrieve pages with similar passages, displaying thumbnail page images with red highlights visible representing the occurrence of searched terms. This visual interface allows for quick review of full pages and search terms to determine the most useful results to view at full-size. An alternate results list is available through the List View, which will display descriptive textual links to individual pages, where search terms will be highlighted in red wherever they occur on the page.</li>
     <li>Selecting a search result will bring up the newspaper page, initially displaying the full page. To read or view the page more closely, select the + or - to magnify the image, use the mouse scroll wheel, or simply click on the page image. Additionally, you can use the cursor hand to &quot;grab&quot; and move the image any direction, within the page frame. To return to the original full-page display, select the &quot;go home&quot; icon on the floating navigation bar.</li>
     <li>In addition to the action icons used for this page image, other icons on this bar provide access to alternate digital formats for this newspaper page which can be downloaded. Click on the text link to download these formats.</li>
-    <li>In some newspapers in <em>Chronicling America</em>, issues or pages in logical sequence are not available digitally (usually because images were absent from the microfilm used for digitization). Whenever possible, any known information about these issues is provided, as follows:    
+    <li>In some newspapers in <em>{{ site_title }}</em>, issues or pages in logical sequence are not available digitally (usually because images were absent from the microfilm used for digitization). Whenever possible, any known information about these issues is provided, as follows:    
         <ul>
             <li>Not digitized, published</li>
             <li>Not digitized, not published</li>
             <li>Not digitized, publishing unknown</li>
         </ul>
-        <p>A good and historically significant example of missing issues is in the <em>San Francisco Call</em>, where the April 19th and April 20th issues from 1906 are missing due to the devastating San Francisco earthquake that prevented the newspaper from publishing on those days.  In this example, the &quot;not digitized, not published&quot; indicator displays as such: <a href="http://chroniclingamerica.loc.gov/lccn/sn85066387/1906-04-19/ed-1/">http://chroniclingamerica.loc.gov/lccn/sn85066387/1906-04-19/ed-1/</a>.</p>
+        <p>A good and historically significant example of missing issues is in the <em>San Francisco Call</em>, where the April 19th and April 20th issues from 1906 are missing due to the devastating San Francisco earthquake that prevented the newspaper from publishing on those days.
     </li>
-    <li>If you have any questions about this information or any other aspects of  <em>Chronicling America</em>, contact the Newspaper and Current Periodicals Reading room via LC&#39;s &quot;Ask a Librarian&quot; service, http://www.loc.gov/rr/askalib/ask-news.html.</li>
 </ul>
             
-<h2 id="language_searching">Searching by Language Chronicling America</h2>
-<p><em>Chronicling America</em> supports language-specific searching in English, French, German, Italian, and Spanish (although not all languages may be represented at this time).  By default, in both  Basic and Advanced Search, all content is searched together regardless of language.  To limit searches to a specific language, conduct an Advanced Search and choose the appropriate language from the Language drop-down menu. For additional technical information on how languages are encoded and identified for search, see current NDNP Technical Guidelines at <a href="http://www.loc.gov/ndnp/guidelines/">http://www.loc.gov/ndnp/guidelines/</a>.</p>
+<h2 id="language_searching">Searching by Language</h2>
+<p><em>{{ site_title }}</em> supports language-specific searching in English, French, German, Italian, and Spanish (although not all languages may be represented at this time).  By default, in both  Basic and Advanced Search, all content is searched together regardless of language.  To limit searches to a specific language, conduct an Advanced Search and choose the appropriate language from the Language drop-down menu. For additional technical information on how languages are encoded and identified for search, see current NDNP Technical Guidelines at <a href="http://www.loc.gov/ndnp/guidelines/">http://www.loc.gov/ndnp/guidelines/</a>.</p>
 
 <h3>Why use language-specific search?</h3>
-<p><em>Chronicling America</em>&#39;s search engine utilizes language-specific dictionaries to include word variants for your search terms.  This is often called &quot;stemming&quot;.  For example, the search term house, when stemmed, would also return words like <b>houses</b> and <b>housing</b>.  In Spanish, words like<b> hermano</b> would include stems such as <b>hermanos</b>. By default, the exact match (unstemmed) results will be ranked higher than the stemmed results.
+<p><em>{{ site_title }}</em>&#39;s search engine utilizes language-specific dictionaries to include word variants for your search terms.  This is often called &quot;stemming&quot;.  For example, the search term house, when stemmed, would also return words like <b>houses</b> and <b>housing</b>.  In Spanish, words like<b> hermano</b> would include stems such as <b>hermanos</b>. By default, the exact match (unstemmed) results will be ranked higher than the stemmed results.
 </p>
 <p>Other reasons for language-specific search may be more content related. For example, reporting in Spanish about the building of the Panama Canal may convey a different perspective than reporting in the mainstream English-speaking press. </p>
-
-<h2 id="searching_directory">Searching the U.S. Newspaper Directory 1690-Present</h2>
-<p>First, review the <b>Basic and Advanced Searching</b> information above. The <em>Chronicling America</em> Newspaper Directory contains more than 150,000 serial title records for historic newspapers published in the United States from 1690 to the present. Also included are hundreds of thousands of Local Data Records indicating which libraries hold which copies and in what format. These records are created and edited by members of the Cooperative Online Serials (CONSER) cataloging program and currently hosted in the OCLC WorldCat bibliographic catalog. A copy of these records has been included in <em>Chronicling America</em>. Updated CONSER records will be added to <em>Chronicling America</em> at regular intervals utilizing the OCLC WorldCat Search API.</p>
-<p>Users can search the Newspaper Directory in a variety of ways, utilizing the data encoded by CONSER catalogers. Search results rely on the unedited CONSER data as it was created in the MARC format.</p>
-<p>Keyword searching will match words that appear in most narrative fields, including newspaper history essays associated with each digitized title. For example, matching an exact phrase, using quotes around the words in the Keyword field, can also be useful if you know a standard Library of Congress subject heading, such as "Anarchism--Newspapers" or "penny papers".</p>
-<p>For the Keyword search box, entering multiple terms will automatically search for matches with all terms (operator = AND).</p>
-<p>You can limit your search for Newspapers in the Directory by a variety of search options. For some users, knowing the origin of these options will help in precise searching. These options rely on specific MARC fields in the title and local data records, as follows:</p>
-<table class="table table-bordered">
-    <tr>
-        <td rowspan="1" colspan="1">State</td><td rowspan="1" colspan="1"> 752 $b</td>
-    </tr>
-    <tr>
-        <td rowspan="1" colspan="1">County</td><td rowspan="1" colspan="1">752 $c</td>
-    </tr>
-    <tr>
-        <td rowspan="1" colspan="1">City</td><td rowspan="1" colspan="1">752 $d</td>
-    </tr>
-    <tr>
-        <td rowspan="1" colspan="1">Begin Year</td>
-        <td rowspan="1" colspan="1">008</td></tr>
-    <tr>
-        <td rowspan="1" colspan="1">End Year</td>
-        <td rowspan="1" colspan="1">008</td></tr>
-    <tr>
-        <td rowspan="1" colspan="1">Frequency</td>
-        <td rowspan="1" colspan="1">008</td></tr>
-    <tr>
-        <td rowspan="1" colspan="1">Language </td>
-        <td rowspan="1" colspan="1">008, 041</td></tr>
-    <tr>
-        <td rowspan="1" colspan="1">Ethnicity Press</td>
-        <td rowspan="1" colspan="1">650</td></tr>
-    <tr>
-        <td rowspan="1" colspan="1">Labor Press</td>
-        <td rowspan="1" colspan="1">650</td></tr>
-    <tr>
-        <td rowspan="1" colspan="1">LCCN</td>
-        <td rowspan="1" colspan="1">010</td></tr>
-    <tr><td rowspan="1" colspan="1">Material Type</td>
-        <td rowspan="1" colspan="1">852</td></tr>
-</table>
 
 <p class="backtotop"><a href="#skip_menu">Top</a></p>
 </div><!-- end id:std_box -->

--- a/core/templates/home.html
+++ b/core/templates/home.html
@@ -7,7 +7,7 @@
 {% block content %}
 <div class="row">
   <div class="col-md-4">
-    <h2>Welcome to the Open Online Newspapers Initiative</h2>
+    <h2>Welcome to the {{ project_full_name }}</h2>
     <p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus</p>
     <p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus</p>
   </div> <!-- /col-md-4 -->
@@ -29,7 +29,7 @@
         <p><a href="{% url 'openoni_issues' %}">Browse issues by date</a></p>
         <p><a href="{% url 'openoni_newspapers' %}">Browse by newspaper title</a></p>
         <p><a href="{% url 'openoni_about' %}">
-          Learn about the Open Online Newspaper Initiative
+          Learn about the {{ project_full_name }}
         </a></p>
       </div>
     {% endif %}

--- a/core/templates/home.html
+++ b/core/templates/home.html
@@ -7,7 +7,7 @@
 {% block content %}
 <div class="row">
   <div class="col-md-4">
-    <h2>Welcome to the {{ project_full_name }}</h2>
+    <h2>Welcome to the {{ project_name }}</h2>
     <p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus</p>
     <p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus</p>
   </div> <!-- /col-md-4 -->
@@ -29,7 +29,7 @@
         <p><a href="{% url 'openoni_issues' %}">Browse issues by date</a></p>
         <p><a href="{% url 'openoni_newspapers' %}">Browse by newspaper title</a></p>
         <p><a href="{% url 'openoni_about' %}">
-          Learn about the {{ project_full_name }}
+          Learn about the {{ project_name }}
         </a></p>
       </div>
     {% endif %}

--- a/core/templates/newspapers.xml
+++ b/core/templates/newspapers.xml
@@ -1,7 +1,7 @@
 {% load image_urls %}{% load custom_filters %}<?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
 
-    <title>Recent Titles from Chronicling America</title>
+    <title>Recent Titles from {{ site_title }}</title>
     <subtitle>This feed lists newspaper titles that have had new content added to them.</subtitle>
     <link rel="self" type="application/atom+xml" href="{{BASE_URL}}{% url 'openoni_newspapers_atom' %}" />
     <link rel="alternate" type="text/html" href="{{BASE_URL}}{% url 'openoni_newspapers' %}" />

--- a/core/templates/reports/awardee.html
+++ b/core/templates/reports/awardee.html
@@ -9,7 +9,7 @@
 
 {% block subcontent %}
 
-<p>Below is some summary information about contributions to Chronicling America
+<p>Below is some summary information about contributions to {{ site_title }}
 from the NDNP Awardee, {{ awardee }}. Summary information about <a href="{% url 'openoni_awardees' %}">all awardees</a> is also available.</p>
 
 <h2>Batches</h2>

--- a/core/templates/reports/awardees.html
+++ b/core/templates/reports/awardees.html
@@ -4,9 +4,9 @@
 {% block subcontent %}
 
 <p>
-Below is a list of NDNP Awardees that have content in the Chronicling 
-America Web Application. Clicking on the name will bring you to a 
-detail page for the awardee, and clicking on the organization code will
+Below is a list of NDNP Awardees that have content in the {{ site_title }} Web Application. 
+Clicking on the name will bring you to a 
+detailed page for the awardee, and clicking on the organization code will
 perform a search of the MARC Organization database.
 </p>
 

--- a/core/templates/reports/batches.html
+++ b/core/templates/reports/batches.html
@@ -14,8 +14,7 @@ The Library of Congress regularly receives digitized newspaper content
 from <a href="{% url 'openoni_awardees' %}">grant awardees</a> in the <a
     href="http://www.loc.gov/ndnp/">National Digital Newspaper Program</a>.
 Content is delivered in the form of batches, where each batch can contain
-one or more issues, from one or more newspapers. As batches are loaded into
-Chronicling America they will appear here. More details about the 
+one or more issues, from one or more newspapers. More details about the 
 batch can be discovered by clicking on the batch name link.
 </p>
 

--- a/core/templates/reports/essays.html
+++ b/core/templates/reports/essays.html
@@ -4,7 +4,7 @@
 
 <p>
 Below is a list of essays provided by NDNP Awardees about newspapers that
-are available in Chronicling America.
+are available in {{ site_title }}.
 </p>
 
 <table class="data table table-striped table-hover">

--- a/core/templates/reports/events.xml
+++ b/core/templates/reports/events.xml
@@ -1,7 +1,7 @@
 {% load custom_filters %}<?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
 
-    <title>Chronicling America Events</title>
+    <title>{{ site_title }} Events</title>
     <link rel="self" type="application/atom+xml" href="{% url 'openoni_events_atom' %}" />
     <link rel="alternate" type="text/html" href="{% url 'openoni_events' %}" />
     <id>info:lc/ndnp/events</id>

--- a/core/templates/reports/languages.html
+++ b/core/templates/reports/languages.html
@@ -3,7 +3,7 @@
 {% block subcontent %}
 
 <p>
-Below is a list of languages found in newspaper text that are available in Chronicling America.
+Below is a list of languages found in newspaper text that are available in {{ site_title }}.
 </p>
 
 <table class="data table table-striped table-hover">

--- a/core/templates/reports/ocr.html
+++ b/core/templates/reports/ocr.html
@@ -5,8 +5,8 @@
 
 {% block extrahead %}
         {{ block.super }}
-        <link rel="alternate" type="application/atom+xml" href="{% url 'openoni_ocr_atom' %}" title="Chronicling America OCR Data Feed" />
-        <link rel="alternate" type="application/json" href="{% url 'openoni_ocr_json' %}" title="Chronicling America OCR Data Feed (JSON)" />
+        <link rel="alternate" type="application/atom+xml" href="{% url 'openoni_ocr_atom' %}" title="{{ site_title }} OCR Data Feed" />
+        <link rel="alternate" type="application/json" href="{% url 'openoni_ocr_json' %}" title="{{ site_title }} OCR Data Feed (JSON)" />
 {% endblock %}
 
 {% block box-tabs %}

--- a/core/templates/reports/ocr.xml
+++ b/core/templates/reports/ocr.xml
@@ -1,7 +1,7 @@
 {% load custom_filters %}<?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
 
-    <title>Chronicling America OCR Data Feed</title>
+    <title>{{ site_title }} OCR Data Feed</title>
     <link rel="self" type="application/atom+xml" href="{{BASE_URL}}{% url "openoni_ocr_atom" %}" />
     <id>info:lc/ndnp/ocr</id>
     <author>

--- a/core/templates/reports/terms.html
+++ b/core/templates/reports/terms.html
@@ -19,11 +19,10 @@
         <h1>National Digital Newspaper Program Vocabulary</h1>
 
         <p>
-        To support RDF views for resources in 
-        <a href="http://chroniclingamerica.loc.gov">Chronicling America</a>
+        To support RDF views for resources in {{ site_title }}
         a few vocabulary elements needed to be created when suitable terms 
         couldn't be found elsewhere. This page is not an exhaustive list of 
-        vocabulary terms in use in Chronicling America linked data views, but 
+        vocabulary terms in use in {{ site_title }} linked data views, but 
         is simply a list of those classes and properties that have been 
         created by the Library of Congress to support Chronicling America and
         the <a href="http://www.loc.gov/ndnp/">National Digital Newspaper Project</a> more generally.

--- a/core/templates/search/search_pages_opensearch.xml
+++ b/core/templates/search/search_pages_opensearch.xml
@@ -2,8 +2,8 @@
 <OpenSearchDescription 
     xmlns="http://a9.com/-/spec/opensearch/1.1/"
     xmlns:openoni="{{BASE_URL}}">
-    <ShortName>Chronicling America Pages Search</ShortName>
-    <Description>Search digital newspaper content from the Library of Congress</Description>
+    <ShortName>{{ site_title }} Pages Search</ShortName>
+    <Description>Search digital newspaper content from {{ site_title }}</Description>
     <InputEncoding>UTF-8</InputEncoding>
     <Image width="16" height="16" type="image/x-icon">{{BASE_URL}}/favicon.ico</Image>
     <Url type="text/html" template="{{BASE_URL}}{% url 'openoni_search_pages_results' %}?andtext={searchTerms}&amp;page={startPage?}&amp;ortext={openoni:booleanOrText?}&amp;year={openoni:year?}&amp;date1={openoni:date?}&amp;date2={openoni:date?}&amp;phrasetext={openoni:phraseText?}&amp;proxText={openoni:proxText?}&amp;proximityValue={openoni:proximityValue?}" />

--- a/core/templates/search/search_pages_results.xml
+++ b/core/templates/search/search_pages_results.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom"
       xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">
 
-    <title>Chronicling America Page Search Results</title>
+    <title>{{ site_title }} Page Search Results</title>
     <link href="{{feed_url}}" rel="self" />
     <id>{{feed_url}}</id>
     <updated>{{updated}}</updated>

--- a/core/templates/search/search_titles_opensearch.xml
+++ b/core/templates/search/search_titles_opensearch.xml
@@ -2,8 +2,8 @@
 <OpenSearchDescription 
     xmlns="http://a9.com/-/spec/opensearch/1.1/"
     xmlns:openoni="{{BASE_URL}}">
-    <ShortName>Chronicling America Titles</ShortName>
-    <Description>Search Chronicling America Titles</Description>
+    <ShortName>{{ site_title }} Titles</ShortName>
+    <Description>Search {{ site_title }} Titles</Description>
     <InputEncoding>UTF-8</InputEncoding>
     <Image width="16" height="16" type="image/x-icon">{{BASE_URL}}/favicon.ico</Image>
     <Url type="text/html" template="{{BASE_URL}}{% url 'openoni_search_titles_results' %}?terms={searchTerms}&amp;page={startPage?}&amp;state={openoni:state?}&amp;count={openoni:county?}&amp;city={openoni:city?}&amp;year1={openoni:year1?}&amp;year2={openoni:year2?}&amp;frequency={openoni:frequency?}&amp;language={openoni:language?}&amp;lccn={openoni:lccn?}&amp;materialType={openoni:materialType?}" />

--- a/core/templates/search/search_titles_results.xml
+++ b/core/templates/search/search_titles_results.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom"
       xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">
 
-    <title>Chronicling America Title Search Results</title>
+    <title>{{ site_title }} Title Search Results</title>
     <link href="{{feed_url}}" rel="self" />
     <id>{{feed_url}}</id>
     <updated>{{updated}}</updated>

--- a/core/templates/site.html
+++ b/core/templates/site.html
@@ -54,146 +54,136 @@ Metadata Etc.
     {% endblock head_content %}
   </head>
 
-  <body role="document">{% block body_content %}
+  <body role="document">
+    {% block body_content %}
 
-<!-- ===========
-HEADER
-============= -->
+      <!-- ===========
+      HEADER
+      ============= -->
 
-  <!-- Site Title/Head -->
+      <!-- Site Title/Head -->
       
-      <div class="header_title">
+      {% block header_title %}
+        <div class="header_title">
+          <div class="container">
+            <h1 class="title">{{ site_title }}</h1>
+          </div>
+        </div><!-- /header -->
+      {% endblock header_title %}
+      <nav class="navbar navbar-inverse">
         <div class="container">
-          <h1 class="title"><span class="title_state">State</span> <span class="title_newspapers">Newspapers</span></h1>
-        </div>
-      </div><!-- /header -->
-
-  
-   <nav class="navbar navbar-inverse">
-  <div class="container">
-    <!-- Brand and toggle get grouped for better mobile display -->
-    <div class="navbar-header">
-      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
-        <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-      </button>
-      
-    </div>
+          <!-- Brand and toggle get grouped for better mobile display -->
+          <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+              <span class="sr-only">Toggle navigation</span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+              <span class="icon-bar"></span>
+            </button>
+          </div>
 
 
-    <!-- Collect the nav links, forms, and other content for toggling -->
-    <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-      <ul class="nav navbar-nav">
-        <li><a href="/">Home</a></li><!--TODO: Is this linked properly? -->
-        <li><a href="{% url 'openoni_newspapers' %}">Newspapers</a></li>
-        <li><a href="{% url 'openoni_about' %}">About</a></li>
-        <li><a href="{% url 'openoni_about_api' %}">API</a></li>
-        <li><a href="{% url 'openoni_issues' %}">Browse by Date</a></li>
-        {# <li><a href="{% url 'openoni_reports' %}">Reports</a></li> <!-- Commenting out because reports should not be available to public -->  #}
-        <li><a href="/help/">Help</a></li>
-      </ul>
+          <!-- Collect the nav links, forms, and other content for toggling -->
+          <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+            <ul class="nav navbar-nav">
+              <li><a href="/">Home</a></li><!--TODO: Is this linked properly? -->
+              <li><a href="{% url 'openoni_newspapers' %}">Newspapers</a></li>
+              <li><a href="{% url 'openoni_about' %}">About</a></li>
+              <li><a href="{% url 'openoni_about_api' %}">API</a></li>
+              <li><a href="{% url 'openoni_issues' %}">Browse by Date</a></li>
+              {# <li><a href="{% url 'openoni_reports' %}">Reports</a></li> <!-- Commenting out because reports should not be available to public -->  #}
+              <li><a href="/help/">Help</a></li>
+            </ul>
 
-      <ul class="nav navbar-nav navbar-right">
-        <li class="nav_advanced_search"><a href="{% url 'openoni_search_advanced' %}">Advanced<br/>Search</a></li>
-      </ul>
-      
-      <form class="form-inline navbar-form navbar-right"  action="{% url 'openoni_search_pages_results' %}" method="get">
-        <div class="form-group">
-          <input type="hidden" name="rows" id="rows" alt="rows" value="20" />
-          <input type="hidden" name="searchType" alt="searchType" value="basic" />
-          <input class="form-control" type="text" name="proxtext" placeholder="search words">
-        </div><!-- /form-group -->
+            <ul class="nav navbar-nav navbar-right">
+              <li class="nav_advanced_search"><a href="{% url 'openoni_search_advanced' %}">Advanced<br/>Search</a></li>
+            </ul>
+          
+            <form class="form-inline navbar-form navbar-right"  action="{% url 'openoni_search_pages_results' %}" method="get">
+              <div class="form-group">
+                <input type="hidden" name="rows" id="rows" alt="rows" value="20" />
+                <input type="hidden" name="searchType" alt="searchType" value="basic" />
+                <input class="form-control" type="text" name="proxtext" placeholder="search words">
+              </div><!-- /form-group -->
 
-        <button type="submit" class="btn btn-default">
-          <span class="glyphicon glyphicon-search" aria-hidden="true"><span class="search_text">Search</span></span>
-        </button>
-    </form>
+              <button type="submit" class="btn btn-default">
+                <span class="glyphicon glyphicon-search" aria-hidden="true"><span class="search_text">Search</span></span>
+              </button>
+            </form>
 
-         </div><!-- /.navbar-collapse -->
-  </div><!-- /.container-fluid -->
-</nav>
+          </div><!-- /.navbar-collapse -->
+        </div><!-- /.container-fluid -->
+      </nav>
 
 
-<!-- ===========
-MAIN CONTENT
-============= -->
+      <!-- ===========
+      MAIN CONTENT
+      ============= -->
 
-    <div class="container main_content">
-      {% if crumbs and crumbs|length > 1 %}
+      <div class="container main_content">
+        {% if crumbs and crumbs|length > 1 %}
 
-    <ol class="breadcrumb">
-      {% for crumb in crumbs %}
-            <li {% if crumb.active %}class="active"{% endif %}>
-              <a href="{{crumb.href}}">{{crumb.label}}</a>
-              {% if forloop.last %}
-              {% else %}
-              {% endif %}
-            </li>
-          {% endfor %}
+          <ol class="breadcrumb">
+            {% for crumb in crumbs %}
+              <li {% if crumb.active %}class="active"{% endif %}>
+                <a href="{{crumb.href}}">{{crumb.label}}</a>
+              </li>
+            {% endfor %}
+          </ol>
+        {% endif %}
 
-     </ol>
-      {% endif %}
-      {% block content %}
-        {% block page_head_container %}
-          {% block page_head %}
-            {% block sub_page_head %}
-              {% if page_title %}
-                <h1>{{ page_title }}</h1>
-              {% endif %}
-            {% endblock sub_page_head %}
-          {% endblock page_head%}
-        {% endblock page_head_container %}
-        <div>
-          <a name="skip_menu"></a>{% block main_content %}{% endblock main_content %}
-        </div>
-        {% block subcontent %}{% endblock subcontent %}
-      {% endblock content %}
-    </div><!--/main_content -->{% endblock body_content %}
+        {% block content %}
+          {% block page_head_container %}
+            {% block page_head %}
+              {% block sub_page_head %}
+                {% if page_title %}
+                  <h1>{{ page_title }}</h1>
+                {% endif %}
+              {% endblock sub_page_head %}
+            {% endblock page_head%}
+          {% endblock page_head_container %}
+          <div>
+            <a name="skip_menu"></a>{% block main_content %}{% endblock main_content %}
+          </div>
+          {% block subcontent %}{% endblock subcontent %}
+        {% endblock content %}
+      </div><!--/main_content -->
+    {% endblock body_content %}
 
-<!-- ===========
-FOOTER
-============= -->
+    <!-- ===========
+    FOOTER
+    ============= -->
 
-<div id="footer">
-<div class="container">
+    <div id="footer">
+      <div class="container">
+        <p>All your footer things like logos and such go here.</p>
+        <p>Site created using <a href="https://github.com/open-oni/open-oni">open-oni</a> software, built off the Library of Congress's <a href="https://github.com/LibraryofCongress/chronam">chronam</a>.</p>
 
-<p>All your footer things like logos and such go here.</p>
-<p>Site created using <a href="https://github.com/open-oni/open-oni">open-oni</a> software, built off the Library of Congress's <a href="https://github.com/LibraryofCongress/chronam">chronam</a>.</p>
+      </div><!-- /container -->
+    </div><!-- /footer -->
 
-</div><!-- /container -->
-</div><!-- /footer -->
-
-<!-- ===========
-Bottom loading javascripts
-============= -->
+    <!-- ===========
+    Bottom loading javascripts
+    ============= -->
 
     {% block javascript %}
+      <!-- JQuery -->
+      <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+      <script type="text/javascript" src="{% static 'vendor/jquery/js/jquery.ba-bbq.min.js' %}"></script>
 
-    <!-- JQuery -->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script type="text/javascript" src="{% static 'vendor/jquery/js/jquery.ba-bbq.min.js' %}"></script>
+      <!-- Main site JS -->
+      <script type="text/javascript" async="" src="{% static 'js/main.js' %}"></script>
+      <script type="text/javascript" async="" src="{% static 'js/highlight.js' %}"></script>
 
-     
-    <!-- Main site JS -->
-    <script type="text/javascript" async="" src="{% static 'js/main.js' %}"></script>
-    <script type="text/javascript" async="" src="{% static 'js/highlight.js' %}"></script>
+      <!-- Bootstrap -->
+      <script type="text/javascript" async="" src="{% static 'vendor/bootstrap/js/bootstrap.min.js' %}"></script>
+      
+      <!-- Google Analytics -->
+      <!-- If you are using Google Analytics add your snippit to the ga.js file -->
+      <script type="text/javascript" async="" src="{% static 'js/ga.js' %}"></script>
+    {% endblock javascript %}
 
-    <!-- Bootstrap -->
-
-    <script type="text/javascript" async="" src="{% static 'vendor/bootstrap/js/bootstrap.min.js' %}"></script>
-  
-    
-    <!-- Google Analytics -->
-    <!-- If you are using Google Analytics add your snippit to the ga.js file -->
-    <script type="text/javascript" async="" src="{% static 'js/ga.js' %}"></script>
-
-
-   
-
-      {% endblock javascript %}
-      <script type="text/javascript">
+    <script type="text/javascript">
       (function($) {
         function initPage() {
           $('ul.nav > li > a[href="' + document.location.pathname + '"]').parent().addClass('active');

--- a/core/templates/title.xml
+++ b/core/templates/title.xml
@@ -1,7 +1,7 @@
 {% load image_urls %}{% load custom_filters %}<?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
 
-    <title>Chronicling America Title Feed: {{ title }}</title>
+    <title>{{ site_title }} Title Feed: {{ title }}</title>
     <link rel="self" type="application/atom+xml" href="{{BASE_URL}}{% url 'openoni_title_atom' title.lccn %}" />
     <link rel="alternate" type="text/html" href="{{BASE_URL}}{% url 'openoni_title' title.lccn %}" />
     <id>info:lc/ndnp/titles/{{ title.lccn }}</id>

--- a/core/tests/title_loader_tests.py
+++ b/core/tests/title_loader_tests.py
@@ -179,7 +179,7 @@ class TitleLoaderTests(TestCase):
 
     def test_etitle(self):
         # we shouldn't load in [electronic resource] records for 
-        # chronicling america titles, since they muddle up search results
+        # titles, since they muddle up search results
         loader = TitleLoader()
         loader.load_file(abs_filename('./test-data/etitle.xml'))
         self.assertRaises(Title.DoesNotExist, Title.objects.get,

--- a/core/views/browse.py
+++ b/core/views/browse.py
@@ -580,7 +580,7 @@ def issues_first_pages(request, lccn, page_number=1):
 @cache_page(settings.DEFAULT_TTL_SECONDS)
 def recommended_topics(request):
     sort_order = request.REQUEST.get('sort_by', None)
-    page_title = 'Topics in Chronicling America'
+    page_title = 'Topics in ' + settings.SITE_TITLE
     crumbs = list(settings.BASE_CRUMBS)
     crumbs.extend([{'label': 'Recommended Topics', 
                    'href': urlresolvers.reverse('recommended_topics')}])

--- a/core/views/static.py
+++ b/core/views/static.py
@@ -7,7 +7,7 @@ from django.template import RequestContext
 
 @cache_page(settings.DEFAULT_TTL_SECONDS)
 def about(request):
-    page_title = "About Chronicling America"
+    page_title = "About " + settings.SITE_TITLE
     crumbs = list(settings.BASE_CRUMBS)
     crumbs.extend([
         {'label':'About',

--- a/settings_base.py
+++ b/settings_base.py
@@ -204,3 +204,13 @@ TOPICS_SUBJECT_URL = '/topicsSubject.html'
 #
 # NOTE: as of now this can NOT include any path elements!
 BASE_URL = 'http://localhost'
+
+# SITE_TITLE that will be used for display purposes throughout app
+# PROJECT_NAME may be the same as SITE_TITLE but can be used
+# for longer descriptions that will only show up occasionally
+# Example "Open ONI" for most headers, "Open Online Newspapers Initiative"
+# for introduction / about / further information / etc
+# Both should be overridden in settings_local.py
+SITE_TITLE = "Open ONI"
+PROJECT_NAME = "Open Online Newspapers Initiative"
+


### PR DESCRIPTION
I recommend you look through the commit messages for details
about the choices that I made

I added two config options, one for long and the other for short project names

The changes to site.html are mostly indentation changes

There are still references to Chronicling America throughout the code, but I did
not remove all of them because in some cases they are actually referring to the
Chronicling America site / project and in other places we need to think more about
how we want to tailor things like the help and about page.