### PR TITLE
Remove conf/openoni-canonical.conf

### DIFF
--- a/conf/openoni-canonical.conf
+++ b/conf/openoni-canonical.conf
@@ -1,4 +1,0 @@
-RewriteCond %{HTTP_HOST}   !^chroniclingamerica\.loc\.gov [NC]
-RewriteCond %{HTTP_HOST}   !^ndn02blp\.loc\.gov [NC]
-RewriteCond %{HTTP_HOST}   !^$
-RewriteRule ^/(.*)         http://chroniclingamerica.loc.gov/$1 [redirect,last]


### PR DESCRIPTION
This file is only useful for LC.  Even if we tried to make it more
general-purpose:

- It's only useful if the system is on a shared server
- We'd need to store a list of host names to not redirect
- It makes more sense to get an Apache config set up to only route to
  the app when the host is correct, rather than redirecting bad hosts