### PR TITLE
Pushes title searching into advanced search

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -14,7 +14,7 @@ DAY_CHOICES = [(i, i) for i in range(1,32)]
 MONTH_CHOICES = ((1, u'Jan',), (2, u'Feb',), (3, u'Mar',),
                  (4, u'Apr',), (5, u'May',), (6, u'Jun',),
                  (7, u'Jul',), (8, u'Aug',), (9, u'Sep',),
-                 (10, u'Oct',), (11, u'Nov',), (12, u'Dec',)) 
+                 (10, u'Oct',), (11, u'Nov',), (12, u'Dec',))
 
 FREQUENCY_CHOICES = (
     ("", "Select"),
@@ -48,12 +48,13 @@ RESULT_SORT = (
     ("date", "Date")
 )
 
+
 def _titles_states():
     """
     returns a tuple of two elements (list of titles, list of states)
 
     example return value:
-    ([('', 'All newspapers'), (u'sn83030214', u'New-York tribune. (New York [N.Y.])')], 
+    ([('', 'All newspapers'), (u'sn83030214', u'New-York tribune. (New York [N.Y.])')],
      [('', 'All states'), (u'New York', u'New York')])
     """
     titles_states = cache.get("titles_states")
@@ -101,7 +102,7 @@ def _fulltext_range():
     return fulltext_range
 
 
-class SearchPagesForm(forms.Form):
+class SearchPagesFormBase(forms.Form):
     state = fields.ChoiceField(choices=[])
     date1 = fields.ChoiceField(choices=[])
     date2 = fields.ChoiceField(choices=[])
@@ -110,7 +111,7 @@ class SearchPagesForm(forms.Form):
     issue_date = fields.BooleanField()
 
     def __init__(self, *args, **kwargs):
-        super(SearchPagesForm, self).__init__(*args, **kwargs)
+        super(SearchPagesFormBase, self).__init__(*args, **kwargs)
 
         self.titles, self.states = _titles_states()
 
@@ -142,7 +143,7 @@ class SearchResultsForm(forms.Form):
         self.fields["sort"].initial = kwargs.get("sort", "relevance")
 
 
-class AdvSearchPagesForm(SearchPagesForm):
+class SearchPagesForm(SearchPagesFormBase):
     date_month = fields.ChoiceField(choices=MONTH_CHOICES)
     date_day = fields.ChoiceField(choices=DAY_CHOICES)
     lccn = fields.MultipleChoiceField(choices=[])
@@ -158,7 +159,7 @@ class AdvSearchPagesForm(SearchPagesForm):
     language = fields.ChoiceField()
 
     def __init__(self, *args, **kwargs):
-        super(AdvSearchPagesForm, self).__init__(*args, **kwargs)
+        super(SearchPagesForm, self).__init__(*args, **kwargs)
 
         self.date = self.data.get('date1', '')
 
@@ -192,6 +193,7 @@ class SearchTitlesForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         super(SearchTitlesForm, self).__init__(*args, **kwargs)
+
         current_year = datetime.date.today().year
         years = range(1690, current_year + 1, 10)
         if years[-1] != current_year:
@@ -203,6 +205,25 @@ class SearchTitlesForm(forms.Form):
         self.fields["year2"].choices = choices
         self.fields["year2"].initial = choices[-1][0]
         self.fields["year2"].widget.attrs["class"] = "norm"
+
+        # location
+        cities = models.Place.objects.values('city').distinct()
+        city = [("", "Select")]
+        city.extend((p["city"], p["city"]) for p in cities)
+        self.fields["city"].choices = city
+        self.fields["city"].label = "City"
+
+        counties = models.Place.objects.values('county').distinct()
+        county = [("", "Select")]
+        county.extend((p["county"], p["county"]) for p in counties)
+        self.fields["county"].choices = county
+        self.fields["county"].label = "County"
+
+        states = models.Place.objects.values('state').distinct()
+        state = [("", "Select")]
+        state.extend((p["state"], p["state"]) for p in states)
+        self.fields["state"].choices = state
+        self.fields["state"].label = "State"
 
         language = [("", "Select"), ]
         language.extend((l.name, l.name) for l in models.Language.objects.all())

--- a/core/templates/search/search_advanced.html
+++ b/core/templates/search/search_advanced.html
@@ -4,27 +4,106 @@
 {% load humanize %}
 
 {% block subcontent %}
-<div>
+
+<div class="title_search">
+    <h2>Search by Title</h2>
+    <fieldset>
+        <legend>Browse by Title First Letter</legend>
+        <ul>
+            {% for val in browse_val %}
+                <li class="alpha_tag"><a href="{% url 'openoni_titles_start' val %}">{{val}}</a></li>
+            {% endfor %}
+        </ul>
+    </fieldset>
+    <form action="{% url 'openoni_search_titles_results' %}" method="get" class="search_directory">
+        <fieldset>
+            <legend>Limit Search</legend>
+            <div class="row">
+                <div class="col-md-3">
+                    <label for="id_city">{{ titles_form.city.label }}:</label>
+                    {{ titles_form.city }}
+                </div>
+                <div class="col-md-3">
+                    <label for="id_county">{{ titles_form.county.label }}:</label>
+                    {{ titles_form.county }}
+                </div>
+                <div class="col-md-3">
+                    <label for="id_state">{{ titles_form.state.label }}:</label>
+                    {{ titles_form.state }}
+                </div>
+                <div class="col-md-3">
+                    <label for="id_frequency">{{ titles_form.frequency.label }}</label>
+                    {{ titles_form.frequency }}
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-4">
+                    <span class="label_alt">Select when the newspaper was published:</span>
+                    {{ titles_form.year1.label }}
+                    {{ titles_form.year1 }}
+                    {{ titles_form.year2.label }}
+                    {{ titles_form.year2 }}
+                </div>
+                <div class="col-md-4">
+                    <label for="id_language">{{ titles_form.language.label }}</label>
+                    {{ titles_form.language }}
+                </div>
+                <div class="col-md-4">
+                    <label for="id_ethnicity">{{ titles_form.ethnicity.label }}</label>
+                    {{ titles_form.ethnicity }}
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-3">
+                    <label for="id_material_type">{{ titles_form.material_type.label }}</label>
+                    {{ titles_form.material_type }}
+                </div>
+                <div class="col-md-4">
+                    <label for="id_material_type">{{ titles_form.labor.label }}</label>
+                    {{ titles_form.labor }}
+                </div>
+                <div class="col-md-3">
+                    <label for="id_lccn">{{ titles_form.lccn.label }}</label>
+                    {{ titles_form.lccn }}
+                </div>
+            </div>
+            <row class="row">
+                <div class="col-md-5">
+                    <label for="id_terms">Keywords:</label>
+                    {{titles_form.terms}}
+                </div>
+            </row>
+        </fieldset>
+        <input type="hidden" name="rows" id="rows" value="20"/>
+        <div class="form-actions">
+            <button id="adv_reset" type="reset" value="clear" class="btn">Clear</button>
+            <button type="submit" value="Submit" class="btn btn-primary">Search</button>
+        </div>
+    </form>
+</div>
+
+<div class="page_search">
+    <h2>Search by Page</h2>
     <form action="{% url 'openoni_search_pages_results' %}" method="get" name="fulltext2" id="fulltext2">
         <fieldset>
             <legend>Limit Search</legend>
             <div class="row">
                 <!-- state -->
                 <div class="col-md-3"> <label for="id_states">Select States:</label>
-                {{ adv_search_form.state }} </div>
+                {{ pages_form.state }} </div>
                 <!-- newspaper -->
                 <div class="col-md-3"> <label for="id_lccns">Or Select Newspapers:</label>
-                {{ adv_search_form.lccn }} </div>
+                {{ pages_form.lccn }} </div>
             </div>
             <div class="row">
                 <!-- page -->
                 <div class="col-md-3">
                     <label for="id_sequence">Specific page</label>
-                    {{ adv_search_form.sequence }}
+                    {{ pages_form.sequence }}
                 </div>
                 <div class="col-md-3"
                     <label for="id_language">Language</label>
-                    {{ adv_search_form.language }}
+                    {{ pages_form.language }}
                 </div>
             </div>
         </fieldset>
@@ -33,15 +112,15 @@
             <!-- date -->
             <!-- send a hidden field specifying that this is a date range -->
             <input type="hidden" name="dateFilterType" alt="dateFilterType" value="yearRange"/>
-            <p class="help-block">Newspaper pages are available for newspapers published between <strong>{{adv_search_form.fulltextStartYear}}-{{adv_search_form.fulltextEndYear}}</strong></p>
+            <p class="help-block">Newspaper pages are available for newspapers published between <strong>{{pages_form.fulltextStartYear}}-{{pages_form.fulltextEndYear}}</strong></p>
             <div class="row">
                 <div class="col-md-2">
                     <label for="id_date_from">from</label>
-                    <input id="id_date_from" name="date1" class="span2" type="text" data-date-format="mm/dd/yyyy" data-date="01-01-{{adv_search_form.fulltextStartYear}}" value="01/01/{{adv_search_form.fulltextStartYear}}">
+                    <input id="id_date_from" name="date1" class="span2" type="text" data-date-format="mm/dd/yyyy" data-date="01-01-{{pages_form.fulltextStartYear}}" value="01/01/{{pages_form.fulltextStartYear}}">
                 </div>
                 <div class="col-md-2">
                     <label for="id_date_to">to</label>
-                    <input id="id_date_to" name="date2" class="span2" type="text" data-date-format="mm/dd/yyyy" data-date="12-31-{{adv_search_form.fulltextEndYear}}" value="12/31/{{adv_search_form.fulltextEndYear}}">
+                    <input id="id_date_to" name="date2" class="span2" type="text" data-date-format="mm/dd/yyyy" data-date="12-31-{{pages_form.fulltextEndYear}}" value="12/31/{{pages_form.fulltextEndYear}}">
                 </div>
             </div>
         </fieldset>
@@ -50,22 +129,22 @@
             <div class="row">
                 <div class="col-md-3">
                     <label for="id_ortext">...with <strong>any</strong> of the words:</label>
-                    {{ adv_search_form.ortext }}
+                    {{ pages_form.ortext }}
                 </div>
                 <div class="col-md-3">
                     <label for="id_andtext">...with <strong>all</strong> of the words:</label>
-                    {{ adv_search_form.andtext }}
+                    {{ pages_form.andtext }}
                 </div>
                 <div class="col-md-3">    
                     <label for="id_phrasetext">...with the <strong>phrase</strong>:</label>
-                    {{ adv_search_form.phrasetext }}
+                    {{ pages_form.phrasetext }}
                 </div>
             </div>    
             <label for="id_proxtext_adv">...with the words:</label>
             <div class="form-inline">
-                {{ adv_search_form.proxtext }}
+                {{ pages_form.proxtext }}
                 <label for="id_proxdistance">within</label>
-                {{ adv_search_form.proxdistance}}
+                {{ pages_form.proxdistance}}
                 <span>words of each other</span>
             </div>
         </fieldset>
@@ -79,4 +158,6 @@
         </fieldset>
     </form>
 </div><!-- end id:tab_advanced_search -->
+
+
 {% endblock subcontent %}

--- a/core/templates/titles.html
+++ b/core/templates/titles.html
@@ -1,4 +1,4 @@
-{% extends "site_base.html" %}
+{% extends "__l_main.html" %}
 {% load static from staticfiles %}
 {% block extrahead %}
     {% if page.has_previous %}

--- a/core/templates/titles.html
+++ b/core/templates/titles.html
@@ -1,0 +1,76 @@
+{% extends "site_base.html" %}
+{% load static from staticfiles %}
+{% block extrahead %}
+    {% if page.has_previous %}
+        {% if start %}
+        <link rel="prev" href="{% url 'openoni_titles_start_page' start page.previous_page_number %}" />
+        {% else %}
+        <link rel="prev" href="{% url 'openoni_titles_page' page.previous_page_number %}" />
+        {% endif %}
+    {% endif %}
+    {% if page.has_next %}
+        {% if start %}
+        <link rel="next" href="{% url 'openoni_titles_start_page' start page.next_page_number %}" />
+        {% else %}
+        <link rel="next" href="{% url 'openoni_titles_page' page.next_page_number %}" />
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
+{% block subcontent %}
+
+<div id="left">
+
+  <div class="browse_collect_ctrl titles top">
+    <h3 class="smaller">Browse the Directory by newspaper title:</h3>
+    <div class="pagination pagination-mini">
+    <ul>
+      {% for val in browse_val %}
+      {% ifequal val start %}
+      <li class="alpha_tag"><a class="off" href="{% url 'openoni_titles_start' val %}">{{val}}</a></li>
+      {% else %}
+      <li class="alpha_tag"><a href="{% url 'openoni_titles_start' val %}">{{val}}</a></li>
+      {% endifequal %}
+      {% endfor %}
+    </ul>
+    </div>
+  </div><!-- end class:browse_collect_ctrl -->
+
+  <div class="search_results_ctrl top titles fix-float">
+    {% include "includes/titles_browse_ctrl.html" %}
+  </div>
+
+  <div id="wrap_searchdir" class="w_pad">
+    <table class="data" width="100%">
+    {% for title in page.object_list %}
+    <tr class="{% cycle 'lightGray' 'white' %}">
+        <td><a href="{% url 'openoni_title' title.lccn %}">{{title}}</a></td>
+    </tr>
+    {% endfor %}
+    </table>
+  </div><!-- end id:wrap_searchdir -->
+
+  <div class="search_results_ctrl bot titles fix-float">
+    {% include "includes/titles_browse_ctrl.html" %}
+  </div>
+  {% endblock %}
+
+  {% block javascript %}
+  {{ block.super }}
+  <script type="text/javascript">
+      jQuery(function($){
+          $("[name=jumptopage]").submit(function(e){
+              e.preventDefault();
+              var base = '{% url 'openoni_titles' %}';
+              var page = this.elements[0].value;
+              {% if start %}
+              window.location.href=base+';start='+'{{start}}'+';page='+page;
+              {% else %}
+              window.location.href=base+';page='+page;
+              {% endif %}
+              });
+          });
+  </script>
+</div>
+
+{% endblock %}

--- a/core/views/__init__.py
+++ b/core/views/__init__.py
@@ -1,4 +1,4 @@
-from search import search_pages_results, search_titles, \
+from search import search_pages_results, \
      search_titles_opensearch,  search_pages_opensearch, suggest_titles
 
 from browse import issues, issues_title, title_holdings, title_marc, \

--- a/core/views/directory.py
+++ b/core/views/directory.py
@@ -82,8 +82,8 @@ def newspapers(request, state=None, format='html'):
                                   context_instance=RequestContext(request),
                                   content_type="text/plain")
     elif format == "csv":
-        csv_header_labels = ('Persistent Link', 'State', 'Title', 'LCCN', 'OCLC', 
-                             'ISSN', 'No. of Issues', 'First Issue Date', 
+        csv_header_labels = ('Persistent Link', 'State', 'Title', 'LCCN', 'OCLC',
+                             'ISSN', 'No. of Issues', 'First Issue Date',
                              'Last Issue Date', 'More Info')
         response = HttpResponse(content_type='text/csv')
         response['Content-Disposition'] = 'attachment; filename="openoni_newspapers.csv"'
@@ -92,11 +92,11 @@ def newspapers(request, state=None, format='html'):
         for state, titles in newspapers_by_state:
             for title in titles:
                 writer.writerow(('%s%s' % (settings.BASE_URL,
-                                                  reverse('openoni_issues_title', 
+                                                  reverse('openoni_issues_title',
                                                            kwargs={'lccn': title.lccn}),),
                                  state, title, title.lccn or '', title.oclc or '',
-                                 title.issn or '', title.issues.count(), title.first, 
-                                 title.last, 
+                                 title.issn or '', title.issues.count(), title.first,
+                                 title.last,
                                  '%s%s' % (settings.BASE_URL, reverse('openoni_title_essays',
                                                            kwargs={'lccn': title.lccn}),),))
         return response
@@ -105,7 +105,7 @@ def newspapers(request, state=None, format='html'):
         host = request.get_host()
 
         results = {
-            "@context": "http://iiif.io/api/presentation/2/context.json", 
+            "@context": "http://iiif.io/api/presentation/2/context.json",
             "@id": settings.BASE_URL + request.get_full_path(),
             "@type": "sc:Collection",
             "label": "Newspapers",
@@ -156,8 +156,8 @@ def newspapers_atom(request):
 def search_titles_results(request):
     page_title = 'Title Search Results'
     crumbs = list(settings.BASE_CRUMBS)
-    crumbs.extend([{'label': 'Title Search',
-                    'href': reverse('openoni_search_titles')},
+    crumbs.extend([{'label': 'Advanced Search',
+                    'href': reverse('openoni_search_advanced')},
                    ])
 
     def prep_title_for_return(t):
@@ -168,22 +168,22 @@ def search_titles_results(request):
 
     format = request.GET.get('format', None)
 
-    # check if requested format is CSV before building pages for response. CSV 
+    # check if requested format is CSV before building pages for response. CSV
     # response does not make use of pagination, instead all matching titles from
     # SOLR are returned at once
     if format == 'csv':
         query = request.GET.copy()
         q, fields, sort_field, sort_order, facets = index.get_solr_request_params_from_query(query)
-        
+
         # return all titles in csv format. * May hurt performance. Assumption is that this
-        # request is not made often. 
+        # request is not made often.
         # TODO: revisit if assumption is incorrect
-        solr_response = index.execute_solr_query(q, fields, sort_field, 
+        solr_response = index.execute_solr_query(q, fields, sort_field,
                                                  sort_order, index.title_count(), 0)
         titles = index.get_titles_from_solr_documents(solr_response)
 
         csv_header_labels = ('lccn', 'title', 'place_of_publication', 'start_year',
-                             'end_year', 'publisher', 'edition', 'frequency', 'subject', 
+                             'end_year', 'publisher', 'edition', 'frequency', 'subject',
                              'state', 'city', 'country', 'language', 'oclc',
                              'holding_type',)
         response = HttpResponse(content_type='text/csv')
@@ -193,15 +193,15 @@ def search_titles_results(request):
         for title in titles:
             writer.writerow(map(lambda val: smart_str(val or '--'),
                                (title.lccn, title.name, title.place_of_publication,
-                                title.start_year, title.end_year, title.publisher, 
-                                title.edition, title.frequency, 
-                                map(str, title.subjects.all()), 
-                                set(map(lambda p: p.state, title.places.all())), 
+                                title.start_year, title.end_year, title.publisher,
+                                title.edition, title.frequency,
+                                map(str, title.subjects.all()),
+                                set(map(lambda p: p.state, title.places.all())),
                                 map(lambda p: p.city, title.places.all()),
                                 str(title.country), map(str, title.languages.all()),
                                 title.oclc, title.holding_types)))
         return response
- 
+
     try:
         curr_page = int(request.GET.get('page', 1))
     except ValueError, e:

--- a/core/views/search.py
+++ b/core/views/search.py
@@ -119,18 +119,22 @@ def search_pages_results(request, view_type='gallery'):
     return render_to_response(template, dictionary=locals(),
                               context_instance=RequestContext(request))
 
-
 @cache_page(settings.DEFAULT_TTL_SECONDS)
-def search_titles(request):
+def search_advanced(request):
+    # page form
+    pages_form = forms.SearchPagesForm()
+
+    # title form
     browse_val = [chr(n) for n in range(65, 91)]
     browse_val.extend([str(i) for i in range(10)])
-    form = forms.SearchTitlesForm()
+    titles_form = forms.SearchTitlesForm()
     title_count = models.Title.objects.all().count()
-    page_name = "directory"
-    page_title = "Search U.S. Newspaper Directory, 1690-Present"
-    template = "news_directory.html"
-    collapse_search_tab = True
+    title_test = models.Place.objects.values('city').distinct()
+
+    # general advanced search
     crumbs = list(settings.BASE_CRUMBS)
+    template = "search/search_advanced.html"
+    page_title = 'Advanced Search'
     return render_to_response(template, dictionary=locals(),
                               context_instance=RequestContext(request))
 
@@ -209,13 +213,3 @@ def search_pages_navigation(request):
     search['next_result'] = paginator.next_result
 
     return HttpResponse(json.dumps(search), content_type="application/json")
-
-
-@cache_page(settings.DEFAULT_TTL_SECONDS)
-def search_advanced(request):
-    adv_search_form = forms.AdvSearchPagesForm()
-    template = "search/search_advanced.html"
-    crumbs = list(settings.BASE_CRUMBS)
-    page_title = 'Advanced Search'
-    return render_to_response(template, dictionary=locals(),
-                              context_instance=RequestContext(request))

--- a/themes/default/static/css/main.css
+++ b/themes/default/static/css/main.css
@@ -3,8 +3,8 @@
 Main stylesheet
 Default Theme
 
-This is where you will put all the styles for your site. 
-Please see the theme's README.md for information on how to override bootstrap if needed. 
+This is where you will put all the styles for your site.
+Please see the theme's README.md for information on how to override bootstrap if needed.
 
 ======================================== */
 
@@ -34,7 +34,7 @@ Header
     color: #fff;
 }
 
-/* using .navbar-inverse rather than .header_navbar so 
+/* using .navbar-inverse rather than .header_navbar so
 it is specific enough to overwrite bootstrap rules */
 
 .navbar-inverse .navbar-nav>li>a {
@@ -56,6 +56,16 @@ h1.title {
 }
 
 /* ==========
+Search
+=========== */
+
+/* TODO this should be moved to another css file in core? */
+.alpha_tag {
+    display: inline-block;
+    list-style-type: none;
+}
+
+/* ==========
 Footer
 =========== */
 
@@ -67,7 +77,7 @@ Footer
 }
 
 /* ==============
-Basic HTML 
+Basic HTML
 ============== */
 
 h1, h2, h3, h4, h5, h6 {
@@ -135,4 +145,4 @@ Breakpoints (Based on bootstrap defaults)
         } /* Make font bigger when screens are bigger */
     }
 
-   
+

--- a/urls.py
+++ b/urls.py
@@ -181,8 +181,6 @@ urlpatterns += patterns(
 
     url('search/titles/opensearch.xml', 'search_titles_opensearch',
         name='openoni_search_titles_opensearch'),
-    url(r'^search/titles/$', 'search_titles', 
-        name="openoni_search_titles"),
     url(r'^search/titles/results/$', 'search_titles_results', 
         name='openoni_search_titles_results'),
     url(r'^suggest/titles/$', 'suggest_titles',


### PR DESCRIPTION
- removes /search/titles in urls.py (use advanced search)
- removes news_directory.html
- merges search_titles with search_advanced in views
- names form SearchPages to SearchPagesBase and AdvSearchPagesForm to SearchPagesForm
  this is because now the advanced search has both pages and titles
  so name changed to match SearchTitlesForm
- Quickly adds the title searching elements to the advanced search UI (looks terrible)
- Adds styling to make the alphabet list horizontal