### PR TITLE
Remove unnecessary shortcut scripts

### DIFF
--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -33,8 +33,6 @@ WORKDIR /opt/openoni
 
 ADD pip-install.sh /
 ADD load_batch.sh /
-ADD purge_batch.sh /
-ADD collect_static.sh /
 ADD startup.sh /
 ADD test.sh /
 ADD manage /usr/local/bin/manage

--- a/docker/collect_static.sh
+++ b/docker/collect_static.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-source /opt/openoni/ENV/bin/activate
-/opt/openoni/manage.py collectstatic --noinput

--- a/docker/purge_batch.sh
+++ b/docker/purge_batch.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-source /opt/openoni/ENV/bin/activate
-/opt/openoni/manage.py purge_batch $1

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -34,7 +34,7 @@ echo "Migrating database" >&2
 
 echo "-------" >&2
 echo "Running collectstatic" >&2
-/collectstatic.sh
+/opt/openoni/manage.py collectstatic --noinput
 
 # Remove any pre-existing PID file which prevents Apache from starting
 #   thus causing the container to close immediately after


### PR DESCRIPTION
Neither of these two are really shortcutting anything now that we have
the "manage" shortcut.  This also fixes collectstatic not being run.