### PR TITLE
Fix test.sh

### DIFF
--- a/docker/test.sh
+++ b/docker/test.sh
@@ -4,11 +4,13 @@ echo "Testing"
 
 cd /opt/openoni
 source ENV/bin/activate
-coverage run --source="." --branch manage.py test --keepdb --settings=onisite.test_settings
+coverage run --source="." --branch \
+    --omit="ENV/*,*_example.py,onisite/settings*,onisite/test_settings.py,onisite/urls.py,core/migrations/*,core/tests/*,core/management/commands/*,onisite/wsgi.py" \
+    manage.py test --keepdb --settings=onisite.test_settings
 rm -rf static/cov
-coverage html -d static/cov/ --omit="ENV/*"
-coverage report --omit="ENV/*,*_example.py" >static/cov/raw.txt
+coverage html -d static/cov/
+coverage report >static/cov/raw.txt
 
 echo
 echo "Visit $APP_URL/coverage to see a coverage report"
-echo "Visit $APP_URL/coverage/raw.txt to see the raw report, including branch information"
+echo "Visit $APP_URL/coverage/raw.txt to see the raw text report"

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -5,7 +5,7 @@ echo "Testing"
 cd /opt/openoni
 source ENV/bin/activate
 coverage run --source="." --branch \
-    --omit="ENV/*,*_example.py,onisite/settings*,onisite/test_settings.py,onisite/urls.py,core/migrations/*,core/tests/*,core/management/commands/*,onisite/wsgi.py" \
+    --omit="ENV/*,*_example.py,onisite/settings*,onisite/test_settings.py,onisite/urls.py,core/migrations/*,core/tests/*,onisite/wsgi.py" \
     manage.py test --keepdb --settings=onisite.test_settings
 rm -rf static/cov
 coverage html -d static/cov/


### PR DESCRIPTION
- Removes suggestion that text report is the only one with branch info
- Omits more files that don't make sense to analyze: various settings,
  migrations, management commands (which presumably can't be tested?),
  and the tests themselves
- Omits files in coverage creation, not reporting, to avoid duping the
  --omit flags