### PR TITLE
about_api: Omit URL examples when there's no data

### DIFF
--- a/core/templates/about_api.html
+++ b/core/templates/about_api.html
@@ -122,34 +122,37 @@ In addition to the use of JSON in OpenSearch results, there are also
 <a href="http://iiif.io">IIIF</a> Presentation API and Image API
 JSON views available for various resources. These IIIF views are
 typically linked from their HTML representation using the &lt;link&gt; element.
-For example: 
-<ul> 
-  <li><a href="{{ title.json_url }}">{{BASE_URL}}{{ title.json_url }}</a> 
-  <br /> 
-  title information for LCCN sn86069873 as an IIIF Collection
-  </li> 
-  <li><a href="{{ issue.json_url }}">{{BASE_URL}}{{ issue.json_url }}</a> 
-  <br />
-  first available edition from January 5, 1900 as an IIIF Manifest
-  </li> 
-  <li><a href="{{ page.json_url }}">{{BASE_URL}}{{ page.json_url }}</a> 
-  <br />
-  first available page from first edition, January 5, 1900 as an IIIF Canvas
-  </li> 
-  <li><a href="/newspapers.json">{{BASE_URL}}/newspapers.json</a>
-  <br>
-  a list of all newspaper titles for which there is digital content represented as
-  a IIIF Collection
-  </li>
-  <li><a href="/batches.json">{{BASE_URL}}/batches.json</a>
-  <br>
-  a list of all batches of content that have been loaded
-  </li>
-  <li><a href="{{ batch.json_url }}">{{BASE_URL}}{{ batch.json_url }}</a>
-  <br>
-  detailed information about a specific batch as a IIIF Collection
-  </li>
-</ul>   
+
+{% if batch %}
+  For example:
+  <ul>
+    <li><a href="{{ title.json_url }}">{{BASE_URL}}{{ title.json_url }}</a>
+    <br />
+    title information for LCCN sn86069873 as an IIIF Collection
+    </li>
+    <li><a href="{{ issue.json_url }}">{{BASE_URL}}{{ issue.json_url }}</a>
+    <br />
+    first available edition from January 5, 1900 as an IIIF Manifest
+    </li>
+    <li><a href="{{ page.json_url }}">{{BASE_URL}}{{ page.json_url }}</a>
+    <br />
+    first available page from first edition, January 5, 1900 as an IIIF Canvas
+    </li>
+    <li><a href="/newspapers.json">{{BASE_URL}}/newspapers.json</a>
+    <br>
+    a list of all newspaper titles for which there is digital content represented as
+    a IIIF Collection
+    </li>
+    <li><a href="/batches.json">{{BASE_URL}}/batches.json</a>
+    <br>
+    a list of all batches of content that have been loaded
+    </li>
+    <li><a href="{{ batch.json_url }}">{{BASE_URL}}{{ batch.json_url }}</a>
+    <br>
+    detailed information about a specific batch as a IIIF Collection
+    </li>
+  </ul>
+{% endif %}
 
 </p>
 <p class="backtotop"><a href="#skip_menu">Top</a></p> 
@@ -176,32 +179,35 @@ publishers of linked data.
 from a list of the newspaper titles available on the site and
 information about each, to enumerations of all the pages that make
 up each issue and all of the files available for each page.</p> 
-<p>Examples:</p> 
 
-<ul> 
-  <li> 
-  <a href="{% url "openoni_title_dot_rdf" title.lccn %}">{{BASE_URL}}{% url "openoni_title_dot_rdf" title.lccn %}</a> 
-  <br /> 
-  information about <a href="{{ title.url }}">{{ title.name }}</a>
-  </li> 
-  <li> 
-  <a href="{{ issue.rdf_url }}">{{BASE_URL}}{{ issue.rdf_url }}</a> 
-  <br /> 
-  information about <a href="{{ issue.url }}">{{ issue }}</a>
-  </li> 
-  <li> 
-  <a href="{{ page.rdf_url }}">{{BASE_URL}}{{ page.rdf_url }}</a> 
-  <br /> 
-  details about all of the files associated with the <a href="{{ page.url }}">{{ page }}</a>
-  </li> 
-  <li><a href="/newspapers.rdf">{{BASE_URL}}/newspapers.rdf</a><br />list of <a href="/newspapers/">available newspaper titles</a></li> 
-</ul> 
+{% if batch %}
+  <p>Examples:</p>
 
-<p>Comparing the RDF versions of the links above with their HTML
-counterpart links, you might notice that the URI pattern we follow for these
-views is to remove the final slash, replacing it with &quot;.rdf&quot;.
-We follow this pattern to comply with best practices for publishing
-linked data, and also to keep the URIs easy to understand and use.</p> 
+  <ul>
+    <li>
+    <a href="{% url "openoni_title_dot_rdf" title.lccn %}">{{BASE_URL}}{% url "openoni_title_dot_rdf" title.lccn %}</a>
+    <br />
+    information about <a href="{{ title.url }}">{{ title.name }}</a>
+    </li>
+    <li>
+    <a href="{{ issue.rdf_url }}">{{BASE_URL}}{{ issue.rdf_url }}</a>
+    <br />
+    information about <a href="{{ issue.url }}">{{ issue }}</a>
+    </li>
+    <li>
+    <a href="{{ page.rdf_url }}">{{BASE_URL}}{{ page.rdf_url }}</a>
+    <br />
+    details about all of the files associated with the <a href="{{ page.url }}">{{ page }}</a>
+    </li>
+    <li><a href="/newspapers.rdf">{{BASE_URL}}/newspapers.rdf</a><br />list of <a href="/newspapers/">available newspaper titles</a></li>
+  </ul>
+
+  <p>Comparing the RDF versions of the links above with their HTML
+  counterpart links, you might notice that the URI pattern we follow for these
+  views is to remove the final slash, replacing it with &quot;.rdf&quot;.
+  We follow this pattern to comply with best practices for publishing
+  linked data, and also to keep the URIs easy to understand and use.</p>
+{% endif %}
 
 <p>For each of the HTML pages with a linked data counterpart in RDF,
 we provide links to those alternate views from the

--- a/core/views/static.py
+++ b/core/views/static.py
@@ -26,11 +26,14 @@ def about_api(request):
          'href': urlresolvers.reverse('openoni_about_api'),
          'active': True},
     ])
-    batch = Batch.objects.all()[0]
-    lccn = batch.lccns()[0]
-    title = Title.objects.get(lccn=lccn)
-    issue = title.issues.all()[0]
-    page = issue.pages.all()[0]
+    batches = Batch.objects.all()
+
+    if len(batches) > 0:
+      batch = batches[0]
+      lccn = batch.lccns()[0]
+      title = Title.objects.get(lccn=lccn)
+      issue = title.issues.all()[0]
+      page = issue.pages.all()[0]
 
     return render_to_response('about_api.html', dictionary=locals(),
                               context_instance=RequestContext(request))


### PR DESCRIPTION
Fixes #214 