### PR TITLE
Fix for iiif manifests

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -684,7 +684,6 @@ class Page(models.Model):
                 "motivation": "sc:painting",
                 "@id": iiif_info_for_page(self),
                 "@type": "oa:Annotation",
-		#"on": settings.BASE_URL + self.url,
 		"on": iiif_info_for_page(self),
                 "rendering": [
                     {"@id": settings.BASE_URL + self.pdf_url, "format": "application/pdf"},
@@ -697,7 +696,7 @@ class Page(models.Model):
             }],
             "label": str(self.sequence),
             "@id": iiif_info_for_page(self),
-            "@type": "sc:Canvas",
+            "@type": "sc:Canvas"
         }
 
         if serialize:

--- a/core/models.py
+++ b/core/models.py
@@ -618,7 +618,9 @@ class Issue(models.Model):
 
         if include_pages:
             j["sequences"] = [{
-                "@id": "normal",
+                # commenting id as it is optional by iiif spec
+		#  ideally, add correct URI
+		#"@id": "normal",
                 "@type": "sc:Sequence",
                 "label": "issue order",
                 "canvases": [p.json(host, False) for p in self.pages.all()]
@@ -682,6 +684,8 @@ class Page(models.Model):
                 "motivation": "sc:painting",
                 "@id": iiif_info_for_page(self),
                 "@type": "oa:Annotation",
+		#"on": settings.BASE_URL + self.url,
+		"on": iiif_info_for_page(self),
                 "rendering": [
                     {"@id": settings.BASE_URL + self.pdf_url, "format": "application/pdf"},
                     {"@id": settings.BASE_URL + self.jp2_url, "format": "image/jp2"},
@@ -693,7 +697,7 @@ class Page(models.Model):
             }],
             "label": str(self.sequence),
             "@id": iiif_info_for_page(self),
-            "@type": "sc:Canvas"
+            "@type": "sc:Canvas",
         }
 
         if serialize:

--- a/core/templates/page.html
+++ b/core/templates/page.html
@@ -149,7 +149,7 @@
 
     <div id="page_data"
 	 data-static_url="{% static '' %}images/"
-   data-iiif_id="{% iiif_info page %}"
+   data-iiif_id="{% iiif_info page %}/info.json"
 	 data-width="{{page.jp2_width}}"
 	 data-height="{{page.jp2_length}}"
 	 data-page_url="{% url 'openoni_page' title.lccn issue.date_issued issue.edition page.sequence %}"

--- a/core/utils/image_urls.py
+++ b/core/utils/image_urls.py
@@ -29,4 +29,4 @@ def image_server_for_page(server_type, page):
     return "%s/%s" % (server, urlquote(page.relative_image_path, safe=""))
 
 def iiif_info_for_page(page):
-    return "%s/info.json" % (image_server_for_page(TILE, page))
+    return "%s" % (image_server_for_page(TILE, page))

--- a/core/views/directory.py
+++ b/core/views/directory.py
@@ -19,7 +19,7 @@ from core import solr_index
 from core.rdf import titles_to_graph
 from core.utils.url import unpack_url_path
 
-
+@cors
 @cache_page(settings.DEFAULT_TTL_SECONDS)
 def newspapers(request, state=None, format='html'):
     if state and state != "all_states":

--- a/themes/default/README.md
+++ b/themes/default/README.md
@@ -4,12 +4,14 @@
 
 This theme is included as part of Open ONI to demonstrate how a theme functions. You can use it out of the box, but if you wish to make changes to it you should make a copy of the theme and add the following to `/settings_local.py`:
 
-```INSTALLED_APPS = (
+```
+INSTALLED_APPS = (
     'django.contrib.humanize',
     'django.contrib.staticfiles',
-    'openoni.themes.YOUR_THEME_NAME_HERE',
-    'openoni.core',
-)```
+    'themes.YOUR_THEME_NAME_HERE',
+    'core',
+)
+```
 
 The INSTALLED_APPS directive will overwrite the directive in `/settings_base.py`.
 


### PR DESCRIPTION
These changes allow for successful validation of our manifest files and use in both [mirador](http://projectmirador.org/demo/) and [universal viewer](http://universalviewer.io/).