### PR TITLE
Modified README.md to deal with error when making custom themes

### DIFF
--- a/themes/default/README.md
+++ b/themes/default/README.md
@@ -7,8 +7,9 @@ This theme is included as part of Open ONI to demonstrate how a theme functions.
 ```INSTALLED_APPS = (
     'django.contrib.humanize',
     'django.contrib.staticfiles',
-    'openoni.themes.YOUR_THEME_NAME_HERE',
-    'openoni.core',
+
+    'themes.YOUR_THEME_NAME_HERE',
+    'core',
 )```
 
 The INSTALLED_APPS directive will overwrite the directive in `/settings_base.py`.


### PR DESCRIPTION
Error when using current settings specfied in README.md results in:

ImportError: No module named openoni.themes