### PR TITLE
enabled docker-compose

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:latest
+MAINTAINER Andrew Gearhart <andrew@psu.edu>
+
+# RUN set -u
+# RUN source docker/urllib.sh
+
+ENV APP_URL=${APP_URL:-}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '2'
+
+services:
+  mysql:
+    image: mysql:latest
+    environment:
+      - MYSQL_ROOT_PASSWORD=123456
+      - MYSQL_DATABASE=openoni
+      - MYSQL_USER=openoni
+      - MYSQL_PASSWORD=openoni
+    volumes:
+      - /var/lib/mysql
+      - ./../conf/mysql/:/etc/mysql/conf.d:Z
+  solr:
+    image: makuk66/docker-solr:4.10.4
+    volumes:
+      - ./solr/schema.xml:/opt/solr/example/solr/collection1/conf/schema.xml:Z
+      - ./solr/solrconfig.xml:/opt/solr/example/solr/collection1/conf/solrconfig.xml:Z
+  rais:
+    image: uolibraries/rais:2.8.0
+    environment:
+      - RAIS_IIIFURL=$APP_URL/images/iiif
+      - RAIS_TILECACHELEN=250
+    volumes:
+      - ./data/batches:/var/local/images:z
+  openoni:
+    build:
+      context: .
+      dockerfile: Dockerfile-dev
+    volumes:
+      - ./../:/opt/openoni:Z
+      - ./data:/opt/openoni/data:z
+    ports:
+      - "80:80"
+    depends_on:
+      - mysql
+    links:
+      - mysql
+      - solr
+      - rais

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 
 services:
-  mysql:
+  rdbms:
     image: mysql:latest
     environment:
       - MYSQL_ROOT_PASSWORD=123456
@@ -11,11 +11,15 @@ services:
     volumes:
       - /var/lib/mysql
       - ./../conf/mysql/:/etc/mysql/conf.d:Z
+      - data-rdbms:/var/lib/mysql
+    ports:
+      - "3306:3306"
   solr:
     image: makuk66/docker-solr:4.10.4
     volumes:
       - ./solr/schema.xml:/opt/solr/example/solr/collection1/conf/schema.xml:Z
       - ./solr/solrconfig.xml:/opt/solr/example/solr/collection1/conf/solrconfig.xml:Z
+      - data-solr:/opt/solr
   rais:
     image: uolibraries/rais:2.8.0
     environment:
@@ -33,8 +37,11 @@ services:
     ports:
       - "80:80"
     depends_on:
-      - mysql
+      - rdbms
     links:
-      - mysql
+      - rdbms
       - solr
       - rais
+volumes:
+  data-rdbms: {}
+  data-solr: {}

--- a/docker/openoni.ini
+++ b/docker/openoni.ini
@@ -9,7 +9,7 @@ BASE_URL=!APP_URL!
 ; Any settings here will override the values in DATABASES['default']
 [database]
 ENGINE=django.db.backends.mysql
-HOST=!DB_HOST!
+HOST=rdbms
 PORT=3306
 NAME=openoni
 USER=openoni
@@ -17,7 +17,7 @@ PASSWORD=openoni
 
 ; Settings here override the Solr URL
 [solr]
-URL=http://!SOLR_HOST!:8983/solr
+URL=http://solr:8983/solr
 
 [images]
 RESIZE_SERVER=!APP_URL!/images/resize

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -15,7 +15,8 @@ sed -i "s/!SECRET_KEY!/$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 80)/g" 
 
 # Refresh the environmental config for DB and Solr hosts in case of IP changes
 cp /etc/openoni.ini.orig /etc/openoni.ini
-sed -i "s/!DB_HOST!/mysql/g" /etc/openoni.ini
+
+sed -i "s/!DB_HOST!/rdbms/g" /etc/openoni.ini
 sed -i "s/!SOLR_HOST!/solr/g" /etc/openoni.ini
 sed -i "s|!APP_URL!|$APP_URL|g" /etc/openoni.ini
 
@@ -29,20 +30,20 @@ cd /opt/openoni
 source ENV/bin/activate
 
 DB_READY=0
-MAX_TRIES=50
+MAX_TRIES=15
 TRIES=0
 while [ $DB_READY == 0 ]
   do
    if
-     ! mysql -uroot -hmysql -p123456 \
+     ! mysql -uroot -hrdbms -p123456 \
        -e 'ALTER DATABASE openoni charset=utf8'
    then
      sleep 5
      let TRIES++
-     echo "Looks like we're still waiting for MySQL ... 5 more seconds ... retry $TRIES of $MAX_TRIES"
+     echo "Looks like we're still waiting for RDBMS ... 5 more seconds ... retry $TRIES of $MAX_TRIES"
      if [ "$TRIES" = "$MAX_TRIES" ]
      then
-      echo "Looks like we couldn't get MySQL running. Could you check settings and try again?"
+      echo "Looks like we couldn't get RDBMS running. Could you check settings and try again?"
       echo "ERROR: The database was not setup properly."
       exit 2
      fi

--- a/onisite/settings_base.py
+++ b/onisite/settings_base.py
@@ -50,6 +50,7 @@ ROOT_URLCONF = 'onisite.urls'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
+        'HOST': 'mysql',
         'NAME': 'openoni',
         'USER': 'openoni',
         'PASSWORD': 'openoni',
@@ -185,6 +186,7 @@ STORAGE_URL = '/data/'
 # below into settings_local.py and uncomment it:
 # MARC_RETRIEVAL_URLFORMAT = "https://raw.githubusercontent.com/open-oni/marc-mirror/master/marc/%s/marc.xml"
 MARC_RETRIEVAL_URLFORMAT = "http://chroniclingamerica.loc.gov/lccn/%s/marc.xml"
+#MARC_RETRIEVAL_URLFORMAT = "http://localhost/media/marc/%s/marc.xml"
 
 # Various storage subdirectories
 BATCH_STORAGE = os.path.join(STORAGE, "batches")

--- a/onisite/settings_base.py
+++ b/onisite/settings_base.py
@@ -50,7 +50,7 @@ ROOT_URLCONF = 'onisite.urls'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
-        'HOST': 'mysql',
+        'HOST': 'rdbms',
         'NAME': 'openoni',
         'USER': 'openoni',
         'PASSWORD': 'openoni',


### PR DESCRIPTION
Tried to make the changes to the other files as minimal as possible, but dev.sh won't quite work with these changes (though, I'm not sure that's a bad thing necessarily).

Notable changes when running with docker compose from the docker directory:
* Containers are named `<directory-name:docker>_<container-name:openoni>_<instance-number:1>` ex: docker_openoni_1, docker_mysql_1, docker_rais_1, docker_solr_1
Usage: git clone the repo, from the docker directory:
* Run with `docker-compose up`
* Stop with `docker-compose stop`
* Kill with `docker-compose down`
~~**Be careful**: Volumes will continue to exist with `stop`, but they will be destroyed with `down`~~
With 9469627, solr index and rdbms data no longer are destroyed. To destroy data requires separately removing the volumes.

Thanks to the PSU Developers who explored the nuances of docker-compose.