### PR TITLE
Fix advanced search multi title selection filter

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -181,7 +181,6 @@ class SearchPagesForm(SearchPagesFormBase):
     proxtext = fields.CharField(label="Words near each other")
     proxdistance = fields.ChoiceField(choices=PROX_CHOICES)
     # misc
-    #lccn1 = fields.CharField(label="LCCN")
     sequence = fields.CharField(label="Page Number")
     lccn = fields.MultipleChoiceField(choices=[])
     # filters
@@ -192,7 +191,7 @@ class SearchPagesForm(SearchPagesFormBase):
         city, county, state, 
         date1, date2, date_day, date_month,
         andtext, ortext, phrasetext, proxtext, proxdistance,
-        lccn, sequence,# lccn1,
+        lccn, sequence,
         language, frequency
     ]
     for item in form_control_items:
@@ -231,12 +230,11 @@ class SearchTitlesForm(forms.Form):
     ethnicity = fields.ChoiceField(choices=[], initial="", label="Ethnicity Press:")
     labor = fields.ChoiceField(choices=[], initial="", label="Labor Press:")
     material_type = fields.ChoiceField(choices=[], initial="", label="Material Type:")
-    #lccn1 = fields.CharField(max_length=255, label="LCCN:")
 
     form_control_items = [
         state, county, city, terms,
         frequency, language, ethnicity, labor,
-        material_type #, lccn1
+        material_type
     ]
     for item in form_control_items:
         item.widget.attrs["class"] = "form-control"

--- a/core/forms.py
+++ b/core/forms.py
@@ -181,7 +181,7 @@ class SearchPagesForm(SearchPagesFormBase):
     proxtext = fields.CharField(label="Words near each other")
     proxdistance = fields.ChoiceField(choices=PROX_CHOICES)
     # misc
-    lccn1 = fields.CharField(label="LCCN")
+    #lccn1 = fields.CharField(label="LCCN")
     sequence = fields.CharField(label="Page Number")
     lccn = fields.MultipleChoiceField(choices=[])
     # filters
@@ -192,7 +192,7 @@ class SearchPagesForm(SearchPagesFormBase):
         city, county, state, 
         date1, date2, date_day, date_month,
         andtext, ortext, phrasetext, proxtext, proxdistance,
-        lccn1, sequence, lccn,
+        lccn, sequence,# lccn1,
         language, frequency
     ]
     for item in form_control_items:
@@ -231,12 +231,12 @@ class SearchTitlesForm(forms.Form):
     ethnicity = fields.ChoiceField(choices=[], initial="", label="Ethnicity Press:")
     labor = fields.ChoiceField(choices=[], initial="", label="Labor Press:")
     material_type = fields.ChoiceField(choices=[], initial="", label="Material Type:")
-    lccn1 = fields.CharField(max_length=255, label="LCCN:")
+    #lccn1 = fields.CharField(max_length=255, label="LCCN:")
 
     form_control_items = [
         state, county, city, terms,
         frequency, language, ethnicity, labor,
-        material_type, lccn1
+        material_type #, lccn1
     ]
     for item in form_control_items:
         item.widget.attrs["class"] = "form-control"

--- a/core/forms.py
+++ b/core/forms.py
@@ -181,9 +181,9 @@ class SearchPagesForm(SearchPagesFormBase):
     proxtext = fields.CharField(label="Words near each other")
     proxdistance = fields.ChoiceField(choices=PROX_CHOICES)
     # misc
-    lccn = fields.CharField(label="LCCN")
+    lccn1 = fields.CharField(label="LCCN")
     sequence = fields.CharField(label="Page Number")
-    titles = fields.MultipleChoiceField(choices=[])
+    lccn = fields.MultipleChoiceField(choices=[])
     # filters
     frequency = fields.ChoiceField(label="Frequency")
     language = fields.ChoiceField(label="Language")
@@ -192,7 +192,7 @@ class SearchPagesForm(SearchPagesFormBase):
         city, county, state, 
         date1, date2, date_day, date_month,
         andtext, ortext, phrasetext, proxtext, proxdistance,
-        lccn, sequence, titles,
+        lccn1, sequence, lccn,
         language, frequency
     ]
     for item in form_control_items:
@@ -203,8 +203,8 @@ class SearchPagesForm(SearchPagesFormBase):
 
         self.date = self.data.get('date1', '')
 
-        self.fields["titles"].widget.attrs.update({'size': '8'})
-        self.fields["titles"].choices = self.titles
+        self.fields["lccn"].widget.attrs.update({'size': '8'})
+        self.fields["lccn"].choices = self.titles
         lang_choices = [("", "All"), ]
         lang_choices.extend((l, models.Language.objects.get(code=l).name) for l in settings.SOLR_LANGUAGES)
         self.fields["language"].choices = lang_choices
@@ -231,12 +231,12 @@ class SearchTitlesForm(forms.Form):
     ethnicity = fields.ChoiceField(choices=[], initial="", label="Ethnicity Press:")
     labor = fields.ChoiceField(choices=[], initial="", label="Labor Press:")
     material_type = fields.ChoiceField(choices=[], initial="", label="Material Type:")
-    lccn = fields.CharField(max_length=255, label="LCCN:")
+    lccn1 = fields.CharField(max_length=255, label="LCCN:")
 
     form_control_items = [
         state, county, city, terms,
         frequency, language, ethnicity, labor,
-        material_type, lccn
+        material_type, lccn1
     ]
     for item in form_control_items:
         item.widget.attrs["class"] = "form-control"

--- a/core/solr_index.py
+++ b/core/solr_index.py
@@ -393,13 +393,25 @@ def page_search(d):
     """
     q = ['+type:page']
 
-    simple_fields = ['city', 'county', 'frequency', 'lccn',
-                     'state', 'titles'
+    simple_fields = ['city', 'county', 'frequency', 
+                     'state'
                     ]
 
     for field in simple_fields:
         if d.get(field, None):
             q.append(query_join(d.getlist(field), field))
+
+    # if d.get('lccn', None):
+    #     q.append(query_join(d.getlist('lccn'), 'lccn'))
+
+    # if d.get('lccn1', None):
+    #     q.append(query_join(d.getlist('lccn1'), 'lccn'))
+    lccn_bld = []
+    if d.get('lccn', None):
+        lccn_bld.append(d.getlist('lccn'))
+    if d.get('lccn1', None):
+        lccn_bld.append(d.getlist('lccn1'))
+    q.append(query_join(list(lccn_bld),'lccn'))
 
     date_filter_type = d.get('dateFilterType', None)
     date_boundaries = _fulltext_range()

--- a/core/solr_index.py
+++ b/core/solr_index.py
@@ -394,24 +394,12 @@ def page_search(d):
     q = ['+type:page']
 
     simple_fields = ['city', 'county', 'frequency', 
-                     'state'
+                     'state', 'lccn'
                     ]
 
     for field in simple_fields:
         if d.get(field, None):
             q.append(query_join(d.getlist(field), field))
-
-    # if d.get('lccn', None):
-    #     q.append(query_join(d.getlist('lccn'), 'lccn'))
-
-    # if d.get('lccn1', None):
-    #     q.append(query_join(d.getlist('lccn1'), 'lccn'))
-    lccn_bld = []
-    if d.get('lccn', None):
-        lccn_bld.append(d.getlist('lccn'))
-    if d.get('lccn1', None):
-        lccn_bld.append(d.getlist('lccn1'))
-    q.append(query_join(list(lccn_bld),'lccn'))
 
     date_filter_type = d.get('dateFilterType', None)
     date_boundaries = _fulltext_range()


### PR DESCRIPTION
Allows the user to select one or more titles from a list of available titles. Previously, if any titles were selected, the search would fail. Also temporarily removes the lccn search field (where the user is able to search for a title by a keyed in lccn).