### PR TITLE
fixes #275 - broken lccn title selection on advanced search page

### DIFF
--- a/core/templates/search/search_advanced.html
+++ b/core/templates/search/search_advanced.html
@@ -89,7 +89,7 @@
         <div class="row">
             <p>Hold cmd to select more than one</p>
             <div class="col-md-12">
-                {{ form.titles }}
+                {{ form.lccn }}
             </div>
         </div>
 
@@ -109,8 +109,7 @@
                 {{ form.sequence }}
             </div>
             <div class="col-md-2">
-                <label for="id_lccn">{{ form.lccn.label }}</label>
-                {{ form.lccn }}
+                &nbsp;
             </div>
         </div>
         {% comment %}


### PR DESCRIPTION
minor change to remove lccn field and replace titles with a multi-select lccn field on the core advanced search page.