### PR TITLE
Fix/image url

### DIFF
--- a/core/templatetags/image_urls.py
+++ b/core/templatetags/image_urls.py
@@ -4,6 +4,10 @@ from core.utils import image_urls
 register = template.Library()
 
 @register.simple_tag
+def tiny_image_url(page):
+    return image_urls.resize_url(page, 120)
+
+@register.simple_tag
 def thumb_image_url(page):
     return image_urls.thumb_image_url(page)
 

--- a/core/utils/image_urls.py
+++ b/core/utils/image_urls.py
@@ -12,7 +12,7 @@ def medium_image_url(page):
     return resize_url(page, 550)
 
 def resize_url(page, size):
-    return  "%s/full/%d,/0/default.jpg" % (image_server_for_page(RESIZE, page), settings.THUMBNAIL_WIDTH)
+    return  "%s/full/%d,/0/default.jpg" % (image_server_for_page(RESIZE, page), size)
 
 def specific_tile_url(page, w, h, x1, y1, x2, y2):
 


### PR DESCRIPTION
Fixes medium images to actually be 550px wide, and gives us an extra size for phones or other small devices