### PR TITLE
Only optimize solr and mysql on request

### DIFF
--- a/core/management/commands/purge_batch.py
+++ b/core/management/commands/purge_batch.py
@@ -11,8 +11,8 @@ from solr import SolrConnection
 
 from core.batch_loader import BatchLoader, BatchLoaderException
 from core.management.commands import configure_logging
-    
-configure_logging('purge_batches_logging.config', 
+
+configure_logging('purge_batches_logging.config',
                   'purge_batch_%s.log' % os.getpid())
 
 log = logging.getLogger(__name__)
@@ -20,10 +20,10 @@ log = logging.getLogger(__name__)
 
 class Command(BaseCommand):
     option_list = BaseCommand.option_list + (
-        make_option('--no-optimize', 
-                    action='store_false', 
-                    dest='optimize', default=True,
-                    help='Do not optimize Solr and MySQL after purge'),
+        make_option('--optimize',
+                    action='store_true',
+                    dest='optimize', default=False,
+                    help='Optimize Solr and MySQL after purge (VERY SLOW)'),
     )
     help = "Purge a batch"
     args = '<batch_location>'


### PR DESCRIPTION
Inverts the flag for purging batches so that it does *not* optimize by
default, as doing so can be extremely slow on a per-batch basis