### PR TITLE
Feature/fix filters

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -181,7 +181,6 @@ class SearchPagesForm(SearchPagesFormBase):
     proxtext = fields.CharField(label="Words near each other")
     proxdistance = fields.ChoiceField(choices=PROX_CHOICES)
     # misc
-    sequence = fields.CharField(label="Page Number")
     lccn = fields.MultipleChoiceField(choices=[])
     # filters
     frequency = fields.ChoiceField(label="Frequency")
@@ -191,7 +190,7 @@ class SearchPagesForm(SearchPagesFormBase):
         city, county, state, 
         date1, date2, date_day, date_month,
         andtext, ortext, phrasetext, proxtext, proxdistance,
-        lccn, sequence,
+        lccn,
         language, frequency
     ]
     for item in form_control_items:

--- a/core/templates/search/search_advanced.html
+++ b/core/templates/search/search_advanced.html
@@ -122,8 +122,8 @@
                 {{ form.frequency }}
             </div>
             <div class="col-md-2">
-                <label for="id_sequence">{{ form.sequence.label }}</label>
-                {{ form.sequence }}
+                <input name="sequence" id="sequence" value="1" type="checkbox" />
+                <label class="norm" for="sequence">Front pages only</label>
             </div>
             <div class="col-md-2">
                 &nbsp;

--- a/core/templates/search/search_pages_results.html
+++ b/core/templates/search/search_pages_results.html
@@ -31,6 +31,18 @@
         <img src="/media/images/btn_remove.png" title="clear language filter" alt="remove language filter"/>
       </a>
     {% endif %}
+
+    {% if titles %}
+        for titles
+        {% for lccn in titles %}
+            {{lccn}}<a href="{{BASE_URL}}{{request.path}}?{% remove_param_value 'lccn' lccn %}">
+                <img src="/media/images/btn_remove.png"
+                    title="clear title filter {{lccn}}"
+                    alt="clear title filter {{lccn}}" />
+            </a>
+            {% if not forloop.last %}, {% endif %}
+        {% endfor %}
+    {% endif %}
 </h4>
 
 <div class="row search_results_option_set">

--- a/core/templates/search/search_pages_results.html
+++ b/core/templates/search/search_pages_results.html
@@ -12,7 +12,8 @@
 {% block subcontent %}
 
 <!-- Search results description -->
-<h4 class="term">{{ paginator.count }} results 
+<h3>Filters</h3>
+<h4 class="term">{{ paginator.count }} results
     {% if english_search %}containing{% endif %} 
     {% for part in english_search %}
       <strong>&ldquo;{{ part }}&rdquo;</strong>
@@ -221,6 +222,7 @@ Thumbnails
 
 {% block search_results_box %}
 <div class="content search_results">
+  <h3>Newspaper Pages</h3>
   <span class="results">Results {{ start }}-{{ end }}<!-- of {{ paginator.count }} removed because it's repeated in another template--></span>
 
 <br/><br/>

--- a/core/templates/search/search_pages_results.html
+++ b/core/templates/search/search_pages_results.html
@@ -214,8 +214,7 @@ Thumbnails
 
 {% block search_results_box %}
 <div class="content search_results">
-  <h3>Newspaper Pages</h3>
-  <span class="results">Results {{ start }}-{{ end }}
+  <h3 class="results">Results {{ start }}-{{ end }}</h3>
 
 <br/><br/>
 

--- a/core/templates/search/search_pages_results.html
+++ b/core/templates/search/search_pages_results.html
@@ -74,21 +74,36 @@
     <form action="" method="GET" class="jumptopage">
       <label for="jumptopage">Jump to page:</label> 
       <input class="std" type="text" id="jumptopage" name="page" value="" size="5" />
+
+      {#### Filter preservation ####}
+
+      {# search text #}
+      <input type="hidden" name="proxtext" value="{{query.proxtext}}" />
       <input type="hidden" name="ortext" value="{{query.ortext}}" />
       <input type="hidden" name="andtext" value="{{query.andtext}}" />
       <input type="hidden" name="phrasetext" value="{{query.phrasetext}}" />
-      <input type="hidden" name="proxtext" value="{{query.proxtext}}" />
-      <input type="hidden" name="proxValue" value="{{query.proxValue}}" />
+
+      {# location #}
+      <input type="hidden" name="city" value="{{query.city}}" />
+      <input type="hidden" name="county" value="{{query.county}}" />
+
+      {# date range #}
+      <input type="hidden" name="dateFilterType" value="{{query.dateFilterType}}" />
       <input type="hidden" name="date1" value="{{query.date1}}" />
       <input type="hidden" name="date2" value="{{query.date2}}" />
-      <input type="hidden" name="year" value="{{query.year}}" />
-      <input type="hidden" name="sort" value="{{query.sort}}" />
-      <input type="hidden" name="dateFilterType" value="{{query.dateFilterType}}" />
-      <input type="hidden" name="state" value="{{query.state}}" />
-      <input type="hidden" name="titles" value="{{query.titles}}" />
-      <input type="hidden" name="rows" value="{{query.rows}}" />
-      <input type="hidden" name="sequence" value="{{query.sequence}}" />
+
+      {# All the chosen LCCNs #}
+      {% for lccn in query.lccn %}
+        <input type="hidden" name="lccn" value="{{lccn}}" />
+      {% endfor %}
+
+      {# miscellaneous filters #}
       <input type="hidden" name="language" value="{{query.language}}" />
+      <input type="hidden" name="frequency" value="{{query.frequency}}" />
+      <input type="hidden" name="sequence" value="{{query.sequence}}" />
+      <input type="hidden" name="sort" value="{{query.sort}}" />
+      <input type="hidden" name="rows" value="{{query.rows}}" />
+
       <input type="submit" class="submit" value="GO" /> 
     </form>
   </div>
@@ -164,18 +179,27 @@
     </div>
   </div>
 
+  {#### Filter preservation ####}
+
+  {# search text #}
+  <input type="hidden" name="proxtext" value="{{query.proxtext}}" />
   <input type="hidden" name="ortext" value="{{query.ortext}}" />
   <input type="hidden" name="andtext" value="{{query.andtext}}" />
   <input type="hidden" name="phrasetext" value="{{query.phrasetext}}" />
-  <input type="hidden" name="proxtext" value="{{query.proxtext}}" />
-  <input type="hidden" name="proxValue" value="{{query.proxValue}}" />
+
+  {# date range #}
+  <input type="hidden" name="dateFilterType" value="{{query.dateFilterType}}" />
   <input type="hidden" name="date1" value="{{query.date1}}" />
   <input type="hidden" name="date2" value="{{query.date2}}" />
-  <input type="hidden" name="year" value="{{query.year}}" />
-  <input type="hidden" name="dateFilterType" value="{{query.dateFilterType}}" />
-  <input type="hidden" name="titles" value="{{query.titles}}" />
+
+  {# All the chosen LCCNs #}
+  {% for lccn in query.lccn %}
+    <input type="hidden" name="lccn" value="{{lccn}}" />
+  {% endfor %}
+
+  {# miscellaneous filters #}
   <input type="hidden" name="language" value="{{query.language}}" />
-  
+
 </form>
 
 <!-- ======================

--- a/core/templates/search/search_pages_results.html
+++ b/core/templates/search/search_pages_results.html
@@ -93,7 +93,7 @@
       <input type="hidden" name="date2" value="{{query.date2}}" />
 
       {# All the chosen LCCNs #}
-      {% for lccn in query.lccn %}
+      {% for lccn in titles %}
         <input type="hidden" name="lccn" value="{{lccn}}" />
       {% endfor %}
 
@@ -193,7 +193,7 @@
   <input type="hidden" name="date2" value="{{query.date2}}" />
 
   {# All the chosen LCCNs #}
-  {% for lccn in query.lccn %}
+  {% for lccn in titles %}
     <input type="hidden" name="lccn" value="{{lccn}}" />
   {% endfor %}
 

--- a/core/templates/search/search_pages_results.html
+++ b/core/templates/search/search_pages_results.html
@@ -163,14 +163,6 @@
         {% endfor %}
       </select>
     </div>
-    {% comment %}
-    <!-- Year requires some work on the backend because solr returns
-        YYYY-YYYY which needs to be sent as 01-01-1988 (date1) and similar
-        date2 fields -->
-    {% endcomment %}
-    {% comment %}
-    <!-- The language requires a translation between human readable and solr codes ("German" vs "ger") -->
-    {% endcomment %}
   </div>
 
   <!-- search preferences -->
@@ -223,7 +215,7 @@ Thumbnails
 {% block search_results_box %}
 <div class="content search_results">
   <h3>Newspaper Pages</h3>
-  <span class="results">Results {{ start }}-{{ end }}<!-- of {{ paginator.count }} removed because it's repeated in another template--></span>
+  <span class="results">Results {{ start }}-{{ end }}
 
 <br/><br/>
 

--- a/core/templatetags/custom_tags.py
+++ b/core/templatetags/custom_tags.py
@@ -1,8 +1,6 @@
 from django import template
-from urllib import urlencode
 
 register = template.Library()
-
 
 @register.simple_tag(takes_context=True)
 def remove_param(context, *args):
@@ -15,7 +13,7 @@ def remove_param(context, *args):
     for arg in args:
         if arg in params:
             del params[arg]
-    return urlencode(params)
+    return params.urlencode()
 
 @register.simple_tag(takes_context=True)
 def remove_param_value(context, key, value):

--- a/core/templatetags/custom_tags.py
+++ b/core/templatetags/custom_tags.py
@@ -16,3 +16,17 @@ def remove_param(context, *args):
         if arg in params:
             del params[arg]
     return urlencode(params)
+
+@register.simple_tag(takes_context=True)
+def remove_param_value(context, key, value):
+    """Given a request.GET or .POST object, shallow clone,
+    and remove a single key/value pair"""
+    request = context["request"]
+    params = request.GET.copy()
+    if key in params:
+        args = params.getlist(key)
+        if value in args:
+            args.remove(value)
+            params.setlist(key, args)
+
+    return params.urlencode()

--- a/core/templatetags/custom_tags.py
+++ b/core/templatetags/custom_tags.py
@@ -4,10 +4,7 @@ register = template.Library()
 
 @register.simple_tag(takes_context=True)
 def remove_param(context, *args):
-    """
-    Given a request.GET or .POST object, shallow clone,
-     and remove list of fields from the new object
-    """
+    """Remove keys from the GET object and return a new URL"""
     request = context["request"]
     params = request.GET.copy()
     for arg in args:
@@ -17,8 +14,7 @@ def remove_param(context, *args):
 
 @register.simple_tag(takes_context=True)
 def remove_param_value(context, key, value):
-    """Given a request.GET or .POST object, shallow clone,
-    and remove a single key/value pair"""
+    """Remove a key/value pair from the GET request and return a new URL"""
     request = context["request"]
     params = request.GET.copy()
     if key in params:

--- a/core/views/search.py
+++ b/core/views/search.py
@@ -105,10 +105,6 @@ def search_pages_results(request, view_type='gallery'):
     # get an pseudo english version of the query
     english_search = paginator.englishify()
 
-    # get some stuff from the query string for use in the form
-    titles = query.getlist('titles')
-    state = query.getlist('state')
-
     form = forms.SearchResultsForm({"rows": rows, "sort": sort})
     if view_type == "list":
         template = "search/search_pages_results_list.html"

--- a/core/views/search.py
+++ b/core/views/search.py
@@ -111,6 +111,7 @@ def search_pages_results(request, view_type='gallery'):
     else:
         template = "search/search_pages_results.html"
     page_list = []
+    titles = query.getlist("lccn")
     for count in range(len(page.object_list)):
         page_list.append((count + start, page.object_list[count]))
     return render_to_response(template, dictionary=locals(),


### PR DESCRIPTION
Fixes https://github.com/uoregon-libraries/oregon-oni/issues/43

- Fixes the search results page forms to properly persist filters
- Properly handles when multiple titles are selected on the advanced search
- Removes the broken "Page Number" filter on advanced search, replaced with "Front pages only"
- Displays titles on the search results when titles are selected on the advanced search
- Removes some unused fields and regroups hidden fields so it's easier to maintain the filter persistence
- Fixes up headings so there's no "gap" and so it's easier to keep the filters separated from the actual search results (thumbnails)