### PR TITLE
Unpin RAIS

### DIFF
--- a/docker-compose.override.yml-example
+++ b/docker-compose.override.yml-example
@@ -1,9 +1,13 @@
-# In this example, we are overriding the docker mysql config to use the more
-# dev-friendly setup (lower RAM usage, for instance).  Copy this to
+# This is an example of overriding the core docker setup.  Copy this to
 # `docker-compose.override.yml` and tweak it however you need for your dev
 # environment.
 version: '2'
 services:
+  # In this example, we are overriding the docker mysql config to use the more
+  # dev-friendly setup (lower RAM usage, for instance).
   rdbms:
     volumes:
       - ./docker/mysql/:/etc/mysql/conf.d:Z
+  # This example pins RAIS to a set version rather than just pulling the latest
+  rais:
+    image: uolibraries/rais:2.10.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     ports:
       - "$SOLRPORT:8983"
   rais:
-    image: uolibraries/rais:2.8.1
+    image: uolibraries/rais
     environment:
       - RAIS_IIIFURL=$APP_URL:$HTTPPORT/images/iiif
       - RAIS_TILECACHELEN=250


### PR DESCRIPTION
When using Docker, the latest RAIS will be installed instead of being pinned to a set version.  The example override now shows how you would pin if you needed to (e.g., for production)