### PR TITLE
provide a link from an issue page to a batch

### DIFF
--- a/core/templates/issue_pages.html
+++ b/core/templates/issue_pages.html
@@ -81,6 +81,7 @@
 {% include "includes/issue_pages_ctrl.html" %}
 {% endif %}
 
+<p class="issue_batch_link"><a href="{{ issue.batch.url }}">View Batch Information</a></p>
 
 {% endblock newspaper_content %}
 


### PR DESCRIPTION
this is the simplest solution to figuring out a batch
for a given page / issue without building an entire
paginated list of issues per batch, etc
closes https://github.com/open-oni/open-oni/issues/345