### PR TITLE
creates / destroys test db each run

### DIFF
--- a/docker/test.sh
+++ b/docker/test.sh
@@ -6,7 +6,7 @@ cd /opt/openoni
 source ENV/bin/activate
 coverage run --source="." --branch \
     --omit="ENV/*,*_example.py,onisite/settings*,onisite/test_settings.py,onisite/urls.py,core/migrations/*,core/tests/*,onisite/wsgi.py" \
-    manage.py test --keepdb --settings=onisite.test_settings
+    manage.py test --settings=onisite.test_settings
 rm -rf static/cov
 coverage html -d static/cov/
 coverage report >static/cov/raw.txt


### PR DESCRIPTION
While working on a branch with a migration, I discovered
that running the tests using the test.sh script was failing
to get the migration while the traditional manage test command
was asking to destroy the db before running. Removed --keepdb
from test.sh options in order to ensure that the tests are running
over freshly migrated and imported database