### PR TITLE
Feature/essay from template

### DIFF
--- a/core/templates/essays/README.md
+++ b/core/templates/essays/README.md
@@ -1,0 +1,43 @@
+## Essays
+
+Essays are included automatically on a newspaper's title page if there is a file in this directory (or the settings.ESSAY_TEMPLATES directory) matching the title LCCN.  For example, the webpage 'lccn/sn99021999' would provide you information about the Omaha Daily Bee and include an essay in `themes/nebraska/templates/essays/sn99021999.html`.
+
+**It is recommended to include essays in a "theme" application rather than adding them in this directory!**
+
+If you are overriding the behavior in `title.html`, you are encouraged to include the `template_exists` filter to prevent errors when including a template file which does not exist.
+
+Example essay:
+
+```
+# <app>/templates/essays/sn99021999.html
+
+<h4>Essay Title</h4>
+
+<p>This is an essay about the <em>Omaha Daily Bee</em>.</p>
+```
+
+## Essays with Multiple Titles
+
+In the case that an essay applies to more than one title, you can avoid duplication by including the shared portion of the essay with the django `{% include "path" %}` tag.  Make sure that you use the "full" path from the `templates` directory in your include tag.
+
+```
+# <app>/templates/essays/sn96080312.html
+
+<h4>The Daily Nebraskan</h4>
+
+{% include "essays/shared/hesperian.html" %}
+```
+
+```
+# <app>/templates/essays/sn96080314.html
+
+<h4>The Hesperian</h4>
+
+{% include "essays/shared/hesperian.html" %}
+```
+
+```
+# <app>/templates/essays/shared/hesperian.html
+
+<p>The Daily Nebraskan, the independent student newspaper at the University of Nebraska-Lincoln (UNL), was founded in 1871. Because it is a student newspaper, it uniquely views major events through the lens of university life. Upon its founding, the newspaper now nicknamed "the DN" was first called the Monthly Hesperian Student [LCCN: sn96080317] and published by the Palladian Literary Society, a student group.</p>
+```

--- a/core/templates/essays/README.md
+++ b/core/templates/essays/README.md
@@ -8,15 +8,32 @@ If a database record and template match the same LCCN, only the first essays in 
 
 Storing essays in the database is not recommended and no essay loading utility for new essays is provided in Open ONI. If you are moving from chronam to Open ONI and your essays are already stored in the database, your essays should appear on the title page out of the box.
 
-Should you need to add new essays for testing purposes, you can use the following clauses in a mysql terminal, where nbu below is substituted to be your awardee code:
+Should you need to add new essays for testing purposes, we must first connect to the database:
 
-```
-INSERT INTO core_essay (title, html, creator_id) VALUES("Title", "<p>Paragraph 1.<p><p>Paragraph 2.</p>", "nbu");
+- If you're running the OpenONI development Docker environment
+    - `docker-compose exec rdbms mysql -u openoni -p -D openoni`
+    - `openoni` is the default password for development
+- On a server running ChronAm
+    - `mysql -u (username) -p -D (database name)`
+    - Database name, username, and password found in `/opt/chronam/settings.py`
+
+Enter the following SQL, where `nbu` below is substituted to be your awardee code:
+
+```sql
+INSERT INTO core_essay
+  (title, html, creator_id, essay_editor_url, created, modified, loaded)
+VALUES
+  ("Title", "<p>Paragraph 1.<p><p>Paragraph 2.</p>", "nbu", "", "1970-01-01 00:00:01", "1970-01-01 00:00:01", "1970-01-01 00:00:01");
 ```
 
-Find the `id` of the essay you just added (3 in this example), then associate it with a particular LCCN:
-
+To determine the `id` of the essay you just added:
+```sql
+SELECT MAX(id), title, html FROM core_essay;
 ```
+
+Associate the essay id (`3` in this example) with a particular LCCN:
+
+```sql
 INSERT INTO core_essay_titles (essay_id, title_id) VALUES(3,"sn83045462");
 ```
 

--- a/core/templates/essays/README.md
+++ b/core/templates/essays/README.md
@@ -1,12 +1,49 @@
 ## Essays
 
-Essays are included automatically on a newspaper's title page if there is a file in this directory (or the settings.ESSAY_TEMPLATES directory) matching the title LCCN.  For example, the webpage 'lccn/sn99021999' would provide you information about the Omaha Daily Bee and include an essay in `themes/nebraska/templates/essays/sn99021999.html`.
+You may add an essay to a particular title in two ways.  For those moving from the chronam software to Open ONI, Open ONI maintains support for pulling HTML essays stored in the database.  If no associated database record is found, however, Open ONI will search for a template with a matching LCCN.  It is recommended that new users rely on templates for essays for ease of editing and version control.
 
-**It is recommended to include essays in a "theme" application rather than adding them in this directory!**
+If a database record and template match the same LCCN, only the first essays in the database will be displayed.  However, there is no restriction on storing some essays in the database and others in the templates for different LCCNs.
 
-If you are overriding the behavior in `title.html`, you are encouraged to include the `template_exists` filter to prevent errors when including a template file which does not exist.
+### Database Storage
 
-Example essay:
+Storing essays in the database is not recommended and no essay loading utility for new essays is provided in Open ONI. If you are moving from chronam to Open ONI and your essays are already stored in the database, your essays should appear on the title page out of the box.
+
+Should you need to add new essays for testing purposes, you can use the following clauses in a mysql terminal, where nbu below is substituted to be your awardee code:
+
+```
+INSERT INTO core_essay (title, html, creator_id) VALUES("Title", "<p>Paragraph 1.<p><p>Paragraph 2.</p>", "nbu");
+```
+
+Find the `id` of the essay you just added (3 in this example), then associate it with a particular LCCN:
+
+```
+INSERT INTO core_essay_titles (essay_id, title_id) VALUES(3,"sn83045462");
+```
+
+### Templates
+
+Essays added as a template must have a filename which exactly matches the title's LCCN in the `ESSAY_TEMPLATES` location.  Check your configuration for the `ESSAY_TEMPLATES` setting.  By default, this is usually `"essays"`.  This path applies to all themes / django `INSTALLED_APPS`.  For example, if your configuration contains:
+
+```
+INSTALLED_APPS = (
+  ...
+  'themes.nebraska',
+  'themes.default',
+  'core'
+)
+
+ESSAY_TEMPLATES = "essays"
+```
+
+You could add essays in the following directories, keeping in mind that **it is recommended to include essays in your custom "theme" application rather than adding them to the core or default apps!**
+
+```
+core/templates/essays/              # no
+themes/default/templates/essays/    # okay, if you do not have a custom theme
+themes/nebraska/templates/essays/   # recommended
+```
+
+If you have one essay for one title, then it is relatively simple to include an essay:
 
 ```
 # <app>/templates/essays/sn99021999.html
@@ -16,12 +53,10 @@ Example essay:
 <p>This is an essay about the <em>Omaha Daily Bee</em>.</p>
 ```
 
-## Essays with Multiple Titles
-
 In the case that an essay applies to more than one title, you can avoid duplication by including the shared portion of the essay with the django `{% include "path" %}` tag.  Make sure that you use the "full" path from the `templates` directory in your include tag.
 
 ```
-# <app>/templates/essays/sn96080312.html
+# themes/nebraska/templates/essays/sn96080312.html
 
 <h4>The Daily Nebraskan</h4>
 
@@ -29,7 +64,7 @@ In the case that an essay applies to more than one title, you can avoid duplicat
 ```
 
 ```
-# <app>/templates/essays/sn96080314.html
+# themes/nebraska/templates/essays/sn96080314.html
 
 <h4>The Hesperian</h4>
 
@@ -37,7 +72,17 @@ In the case that an essay applies to more than one title, you can avoid duplicat
 ```
 
 ```
-# <app>/templates/essays/shared/hesperian.html
+# themes/nebraska/templates/essays/shared/hesperian.html
 
-<p>The Daily Nebraskan, the independent student newspaper at the University of Nebraska-Lincoln (UNL), was founded in 1871. Because it is a student newspaper, it uniquely views major events through the lens of university life. Upon its founding, the newspaper now nicknamed "the DN" was first called the Monthly Hesperian Student [LCCN: sn96080317] and published by the Palladian Literary Society, a student group.</p>
+<p>The Daily Nebraskan, the independent student newspaper at the University of Nebraska-Lincoln (UNL), was founded in 1871 as the Monthly Hesperian Student [LCCN: sn96080317].</p>
+```
+
+One benefit of adding the essays to templates is that you have the full power of django templating at your disposal.  You may use django helpers for images, links, block overriding, or whatever else you may need.
+
+Be aware, if you are overriding the behavior in `title.html`, you should include the `template_exists` filter to prevent errors when including a template file which does not exist.
+
+```
+{% if essay_template|template_exists %}
+    {% include essay_template %}
+{% endif %}
 ```

--- a/core/templates/title.html
+++ b/core/templates/title.html
@@ -233,7 +233,13 @@
         <div class="about_issue_more">
             {% block essay %}
                 <div class="title_essay">
-                    {% if essay_template|template_exists %}
+                    {# if there is an essay in the database, display, otherwise check for a template #}
+                    {% if first_essay %}
+                        {# older essays in db include title as separate field #}
+                        <h4>{{first_essay.title}}</h4>
+                        <p>{{first_essay.html|safe}}</p>
+                        <p><em>Provided by: <a href="{% url 'openoni_awardee' first_essay.creator.org_code %}">{{ first_essay.creator }}</a></em></p>
+                    {% elif essay_template|template_exists %}
                         {% include essay_template %}
                     {% endif %}
                 </div>

--- a/core/templates/title.html
+++ b/core/templates/title.html
@@ -211,16 +211,6 @@
             <dd><a id="page_nav_marc" href="{% url 'openoni_title_marc' title.lccn %}">Record</a></dd>
         </dl>
 
-        <div class="title_essay">
-        {% if first_essay %}
-            
-            <h4>{{first_essay.title}}</h4>
-            <p>{{first_essay.html|safe}}</p>
-            <p><em>Provided by: <a href="{% url 'openoni_awardee' first_essay.creator.org_code %}">{{ first_essay.creator }}</a></em></p>
-            
-        <!-- end class:more -->
-        {% endif %}
-        </div><!-- /title_essay -->
     </div><!-- /col-md-7 -->
 
     <div class="col-md-5">
@@ -240,15 +230,15 @@
             </div>
         </div>
         {% endif %}
-        {% if first_essay %}
         <div class="about_issue_more">
-            <div class="title_essay">
-            <h4>{{first_essay.title}}</h4>
-            <p>{{first_essay.html|safe}}</p>
-            <p><em>Provided by: <a href="{% url 'openoni_awardee' first_essay.creator.org_code %}">{{ first_essay.creator }}</a></em></p>
-            </div>
+            {% block essay %}
+                <div class="title_essay">
+                    {% if essay_template|template_exists %}
+                        {% include essay_template %}
+                    {% endif %}
+                </div>
+            {% endblock essay %}
         </div><!-- end class:more -->
-        {% endif %}
     </div><!-- /col_md_5 -->
 </div><!-- /row -->
 {% endblock %}

--- a/core/templatetags/custom_filters.py
+++ b/core/templatetags/custom_filters.py
@@ -1,4 +1,5 @@
 from django import template
+from django.template.defaultfilters import stringfilter
 
 from rfc3339 import rfc3339
 
@@ -21,3 +22,14 @@ def pack_url(value, default='-'):
 def _label(value):
     return label(value)
 
+
+
+@register.filter
+@stringfilter
+# from https://stackoverflow.com/a/18951166/4154134
+def template_exists(value):
+    try:
+        template.loader.get_template(value)
+        return True
+    except template.TemplateDoesNotExist:
+        return False

--- a/core/views/browse.py
+++ b/core/views/browse.py
@@ -304,11 +304,11 @@ def title(request, lccn):
         if num_notes >= 1:
             explanation = rep_notes[0].text
 
-    # adding essay info on this page if it exists
-    first_essay = title.first_essay
     first_issue = title.first_issue
     if first_issue:
         issue_date = first_issue.date_issued
+
+    essay_template = os.path.join(settings.ESSAY_TEMPLATES, title.lccn+".html")
 
     crumbs = create_crumbs(title)
     response = render(request, 'title.html', locals())

--- a/core/views/browse.py
+++ b/core/views/browse.py
@@ -308,6 +308,8 @@ def title(request, lccn):
     if first_issue:
         issue_date = first_issue.date_issued
 
+    # add essay info on this page from either the database or from a template
+    first_essay = title.first_essay
     essay_template = os.path.join(settings.ESSAY_TEMPLATES, title.lccn+".html")
 
     crumbs = create_crumbs(title)

--- a/onisite/settings_development.py
+++ b/onisite/settings_development.py
@@ -45,6 +45,10 @@ MIDDLEWARE = (
 # NOTE: as of now this can NOT include any path elements!
 BASE_URL = 'http://localhost'
 
+# Relative path from core and theme apps to subdirectory where essay templates are stored
+# example: "essays" would find files in themes/default/templates/essays
+ESSAY_TEMPLATES = "essays"
+
 IS_PRODUCTION = False
 
 LOG_LOCATION = '/opt/openoni/log/'
@@ -75,10 +79,6 @@ TEMP_TEST_DATA = os.path.join(STORAGE, 'temp_test_data')
 
 # URL path to the data directory
 STORAGE_URL = '/data/'
-
-# Relative path from core and theme apps to subdirectory where essay templates are stored
-# example: "essays" would find files in themes/default/templates/essays
-ESSAY_TEMPLATES = "essays"
 
 # Number of processes in system run queue averaged over last minute beyond which
 # OpenONI will return a 'Server Too Busy' response; If unsure, leave at default

--- a/onisite/settings_development.py
+++ b/onisite/settings_development.py
@@ -76,6 +76,10 @@ TEMP_TEST_DATA = os.path.join(STORAGE, 'temp_test_data')
 # URL path to the data directory
 STORAGE_URL = '/data/'
 
+# Relative path from core and theme apps to subdirectory where essay templates are stored
+# example: "essays" would find files in themes/default/templates/essays
+ESSAY_TEMPLATES = "essays"
+
 # Number of processes in system run queue averaged over last minute beyond which
 # OpenONI will return a 'Server Too Busy' response; If unsure, leave at default
 # Requires core.middleware.TooBusyMiddleware in MIDDLEWARE_CLASSES

--- a/onisite/settings_local_example.py
+++ b/onisite/settings_local_example.py
@@ -119,6 +119,10 @@ INSTALLED_APPS = (
 # URL path to the data directory
 #STORAGE_URL = '/data/'
 
+# Relative path from core and theme apps to subdirectory where essay templates are stored
+# example: "essays" would find files in themes/default/templates/essays
+# ESSAY_TEMPLATES = "essays"
+
 # Number of processes in system run queue averaged over last minute beyond which
 # OpenONI will return a 'Server Too Busy' response; If unsure, leave at default
 # Requires core.middleware.TooBusyMiddleware in MIDDLEWARE

--- a/onisite/settings_local_example.py
+++ b/onisite/settings_local_example.py
@@ -91,6 +91,10 @@ INSTALLED_APPS = (
 # NOTE: as of now this can NOT include any path elements!
 #BASE_URL = 'http://YOUR_HOSTNAME'
 
+# Relative path from core and theme apps to subdirectory where essay templates are stored
+# example: "essays" would find files in themes/default/templates/essays
+# ESSAY_TEMPLATES = "essays"
+
 #LOG_LOCATION = '/opt/openoni/log/'
 
 # Enable HSTS by setting SECURE_HSTS_SECONDS > 0
@@ -118,10 +122,6 @@ INSTALLED_APPS = (
 
 # URL path to the data directory
 #STORAGE_URL = '/data/'
-
-# Relative path from core and theme apps to subdirectory where essay templates are stored
-# example: "essays" would find files in themes/default/templates/essays
-# ESSAY_TEMPLATES = "essays"
 
 # Number of processes in system run queue averaged over last minute beyond which
 # OpenONI will return a 'Server Too Busy' response; If unsure, leave at default

--- a/requirements.lock
+++ b/requirements.lock
@@ -11,7 +11,7 @@ idna==2.7
 isodate==0.6.0
 libsass==0.16.1
 lxml==4.2.5
-mysqlclient==1.3.13
+mysqlclient==1.3.14
 Pillow==5.3.0
 pip==18.1
 pymarc==3.1.11


### PR DESCRIPTION
If title has matching essay in DB, loads as HTML. If not, checks for template with matching LCCN
Adds setting to change essay template path
Readme for instructions added to core
Based on this original PR https://github.com/open-oni/open-oni/pull/354 which removed all the database components, now allows legacy projects to continue to use database essays but recommended to use templates instead

closes #350 