### PR TITLE
Feature/small changes

### DIFF
--- a/core/templates/newspapers.html
+++ b/core/templates/newspapers.html
@@ -15,12 +15,15 @@
 {% if titles.count > 0 %}
 
 <div class="search_results_body">
+    {% block newspapers_table_intro %}
     <div class="results_nav">
         <p class="term">
             {{ titles.count|intcomma }} newspaper{% if titles.count > 1 %}s{% endif %}
             {% if titles.count == 1 %}is{% else %}are{% endif %} available for viewing on this site. 
         </p>
     </div>
+    {% endblock newspapers_table_intro %}
+    {% block newspapers_table %}
     <table id="newspapers" class="table table-striped table-hover browse_collect tablesorter" cellspacing="0" summary="">
         <thead>
         <tr>
@@ -53,6 +56,7 @@
         {% endfor %}
         </tbody>
     </table>
+    {% endblock newspapers_table %}
     <div class="txt_wrapper">
         <p class="backtotop"><a href="#skip_menu">Top</a></p>
     </div>

--- a/core/views/browse.py
+++ b/core/views/browse.py
@@ -247,7 +247,6 @@ def page(request, lccn, date, edition, sequence, words=None):
     host = request.get_host()
 
     template = "page.html"
-    related_pages = solr_index.similar_pages(page)
     response = render(request, template, locals())
     return response
 


### PR DESCRIPTION
open oni doesn't have a "view similar pages" feature on page.html so removes unused variable
breaks newspapers.html table template into a few more blocks
this is because Nebraska wants to change the introduction text but we don't want to copy in the
entire table as well to change that (see https://github.com/CDRH/open-oni_nebraska_theme/blob/51c4cf936db085b493ede35db62202755ea1b12a/templates/newspapers.html to see how we used override)