### PR TITLE
Batch loader fixes

### DIFF
--- a/core/batch_loader.py
+++ b/core/batch_loader.py
@@ -104,8 +104,11 @@ class BatchLoader(object):
         """
         self.pages_processed = 0
 
+        # Trailing slash breaks comparison to link_name below, so strip off
+        batch_path = batch_path.rstrip("/")
+
         _logger.info("loading batch at %s", batch_path)
-        dirname, batch_name = os.path.split(batch_path.rstrip("/"))
+        dirname, batch_name = os.path.split(batch_path)
         if dirname:
             batch_source = None
             link_name = os.path.join(settings.BATCH_STORAGE, batch_name)

--- a/core/batch_loader.py
+++ b/core/batch_loader.py
@@ -104,7 +104,7 @@ class BatchLoader(object):
         """
         self.pages_processed = 0
 
-        logging.info("loading batch at %s", batch_path)
+        _logger.info("loading batch at %s", batch_path)
         dirname, batch_name = os.path.split(batch_path.rstrip("/"))
         if dirname:
             batch_source = None
@@ -256,7 +256,7 @@ class BatchLoader(object):
             title = Title.objects.get(lccn=lccn)
         except Exception, e:
             url = settings.MARC_RETRIEVAL_URLFORMAT % lccn
-            logging.info("attempting to load marc record from %s", url)
+            _logger.info("attempting to load marc record from %s", url)
             management.call_command('load_titles', url)
             title = Title.objects.get(lccn=lccn)
 
@@ -447,7 +447,7 @@ class BatchLoader(object):
         f.close()
 
     def process_coordinates(self, batch_path):
-        logging.info("process word coordinates for batch at %s", batch_path)
+        _logger.info("process word coordinates for batch at %s", batch_path)
         dirname, batch_name = os.path.split(batch_path.rstrip("/"))
         if dirname:
             batch_source = None

--- a/core/batch_loader.py
+++ b/core/batch_loader.py
@@ -112,7 +112,14 @@ class BatchLoader(object):
         if dirname:
             batch_source = None
             link_name = os.path.join(settings.BATCH_STORAGE, batch_name)
-            if batch_path != link_name and not os.path.islink(link_name):
+
+            # Create symlink if paths don't match, symlink not already there,
+            # and batch_path wasn't input with a BATCH_STORAGE symlink path
+            if (batch_path != link_name and not os.path.islink(link_name)
+                and not (os.path.islink(settings.BATCH_STORAGE)
+                    and batch_path.startswith(os.path.realpath(settings.BATCH_STORAGE))
+                    )
+                ):
                 _logger.info("creating symlink %s -> %s", batch_path, link_name)
                 os.symlink(batch_path, link_name)
         else:


### PR DESCRIPTION
- Fix logging calls to use `_logger`
- Fix unreliable path comparison due to trailing slash
- Handle `load_batch` command `batch_path` input with `BATCH_STORAGE` symlink