### PR TITLE
adds custom image size tag for templates

### DIFF
--- a/core/templatetags/image_urls.py
+++ b/core/templatetags/image_urls.py
@@ -4,6 +4,10 @@ from core.utils import image_urls
 register = template.Library()
 
 @register.simple_tag
+def custom_size_image_url(page, size):
+  return image_urls.resize_url(page, size)
+
+@register.simple_tag
 def tiny_image_url(page):
     return image_urls.resize_url(page, 120)
 


### PR DESCRIPTION
nebraska needs an image size part ways between a thumb and a medium
tag so adding a custom size tag for cases where one of the standard sizes
does not fit the case