### PR TITLE
remove unused newspaper_info context processor and cache

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -30,36 +30,3 @@ def cors(request):
     without requiring proxying.
     """
     pass
-
-
-def newspaper_info(request):
-    info = cache.get("newspaper_info")
-    if info is None:
-        total_page_count = solr_index.page_count()
-        titles_with_issues = models.Title.objects.filter(has_issues=True)
-        titles_with_issues_count = titles_with_issues.count()
-
-        _places = models.Place.objects.filter(titles__in=titles_with_issues)
-        states_with_issues = sorted(set(place.state for place in _places if place.state is not None))
-
-        _languages = models.Language.objects.filter(titles__in=titles_with_issues)
-        languages_with_issues = sorted(set((lang.code, lang.name) for lang in _languages))
-
-        # TODO: might make sense to add a Ethnicity.has_issue model field
-        # to save having to recompute this all the time, eventhough it
-        # shouldn't take more than 1/2 a second, it all adds up eh?
-        ethnicities_with_issues = []
-        for e in models.Ethnicity.objects.all():
-            # fliter out a few ethnicities, not sure why really
-            if e.has_issues and e.name not in ["African", "Canadian", "Welsh"]:
-                ethnicities_with_issues.append(e.name)
-
-        info = {'titles_with_issues_count': titles_with_issues_count,
-                'states_with_issues': states_with_issues,
-                'languages_with_issues': languages_with_issues,
-                'ethnicities_with_issues': ethnicities_with_issues,
-                'total_page_count': total_page_count}
-
-        cache.set("newspaper_info", info)
-
-    return info

--- a/core/management/commands/delete_cache.py
+++ b/core/management/commands/delete_cache.py
@@ -20,9 +20,6 @@ class Command(BaseCommand):
             raise CommandError('Usage is `manage.py delete_cache`')
 
         try:
-            logger.info("Deleting newspaper_info cache...")
-            cache.delete('newspaper_info')
-
             logger.info("Deleting titles_states cache...")
             cache.delete('titles_states')
         except Exception, e:

--- a/core/management/commands/purge_django_cache.py
+++ b/core/management/commands/purge_django_cache.py
@@ -16,10 +16,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
 
         try:
-            # delete the total pages count
-            LOGGER.info('removing newspaper_info from cache')
-            cache.delete('newspaper_info')
-
             # delete the advanced search title list
             LOGGER.info('removing titles_states from cache')
             cache.delete('titles_states')

--- a/onisite/settings_base.py
+++ b/onisite/settings_base.py
@@ -54,7 +54,6 @@ TEMPLATES = [
                 'django.template.context_processors.static',
                 'django.template.context_processors.tz',
                 'core.context_processors.extra_request_info',
-                'core.context_processors.newspaper_info',
             ],
         },
     },


### PR DESCRIPTION
verified that this used to be relied upon by chronam
but no longer in openoni core

noticed because when cache is set to clear constantly in
development with sensitive logging, there are an incredible
amount of hits for languages and ethnicities for even basic
pages like "about" which should have no queries, typically
the cache would take care of that but if we don't need this code
then we should just get rid of it!