### PR TITLE
adds page count to newspapers newspapers_table_intro block

### DIFF
--- a/core/templates/newspapers.html
+++ b/core/templates/newspapers.html
@@ -18,8 +18,7 @@
     {% block newspapers_table_intro %}
     <div class="results_nav">
         <p class="term">
-            {{ titles.count|intcomma }} newspaper{% if titles.count > 1 %}s{% endif %}
-            {% if titles.count == 1 %}is{% else %}are{% endif %} available for viewing on this site. 
+            {{ titles.count|intcomma }} newspaper{{ titles.count|pluralize }} with {{ page_count|intcomma }} page{{ page_count|pluralize }} available for viewing on this site.
         </p>
     </div>
     {% endblock newspapers_table_intro %}

--- a/core/views/directory.py
+++ b/core/views/directory.py
@@ -23,6 +23,7 @@ from core.utils.url import unpack_url_path
 @cache_page(settings.DEFAULT_TTL_SECONDS)
 def newspapers(request, city=None, format='html'):
     page_title = 'All Titles'
+    page_count = models.Page.objects.count()
     titles = models.Title.objects.filter(has_issues=True)
     titles = titles.annotate(first=Min('issues__date_issued'))
     titles = titles.annotate(last=Max('issues__date_issued'))


### PR DESCRIPTION
still quite overrideable but provides functionality for those
who wish to display the page count
if this would be helpful in more templates we should consider
moving the functionality to a context processor or template tag, etc

this problem was introduced when removing the newspapers_info context processor
from which Nebraska was pulling our page count #378 