### PR TITLE
pull out page nav to reuse

### DIFF
--- a/core/templates/search/search_pages_results.html
+++ b/core/templates/search/search_pages_results.html
@@ -62,89 +62,10 @@
 {% endblock search_page_filter_desc %}
 
 {% block search_page_option_set %}
-  {# Sorry for this, but I'm trying to space this so it's clear where the django #}
-  {# template logic flows while still making it clear which HTML tags wrap #}
-  {# what....  Pagination should probably be a helper method of some kind. #}
   <div class="row search_results_option_set">
-    <div class="col-md-7">
-      <!-- Pagination -->
-      <nav aria-label="Pages">
-        <ul class="pagination pagination-sm">
-  {% if page.has_previous %}
-          <li><a href="{{previous_url}}" aria-label="Previous Page"><span aria-hidden="true">&laquo;</span></a></li>
-  {% else %}
-          <li class="disabled"><span aria-hidden="true">&laquo;</span></li>
-  {% endif %}
+    {% search_pages_results_pagination %}
+    {% search_pages_results_page_jump %}
 
-  {% for page_number in page_range_short %}
-    {% ifequal page_number "..." %}
-          <li class="disabled"><a>…</a></li>
-    {% else %}
-      {% ifequal page_number page.number %}
-          <li class="active" aria-current="true">
-      {% else %}
-          <li>
-      {% endifequal %}
-            <a href="?{{q}}&amp;page={{page_number}}&amp;sort={{sort}}" aria-label="Page {{page_number}}">{{page_number}}</a>
-          </li>
-    {% endifequal %}
-  {% endfor %}
-
-  {% if page.has_next %}
-          <li><a href="{{next_url}}" aria-label="Next Page"><span aria-hidden="true">&raquo;</span></a></li>
-  {% else %}
-          <li class="disabled"><span aria-hidden="true">&raquo;</span></li>
-  {% endif %}
-        </ul>
-      </nav>
-    <!-- /pagination -->
-    </div>
-
-    <div class="col-md-3">
-    <!-- Jump to page -->
-      <form action="" method="GET" class="jumptopage">
-        <label for="jumptopage">Jump to page:</label>
-        <input class="std" type="text" id="jumptopage" name="page" value="" size="5" />
-
-        {% block search_page_pagination_hidden_filters %}
-          {#### Filter preservation ####}
-
-          {# search text #}
-          <input type="hidden" name="proxtext" value="{{query.proxtext}}" />
-          <input type="hidden" name="proxdistance" value="{{query.proxdistance}}" />
-          <input type="hidden" name="ortext" value="{{query.ortext}}" />
-          <input type="hidden" name="andtext" value="{{query.andtext}}" />
-          <input type="hidden" name="phrasetext" value="{{query.phrasetext}}" />
-
-          {# location #}
-          <input type="hidden" name="city" value="{{query.city}}" />
-          <input type="hidden" name="county" value="{{query.county}}" />
-
-          {# date range and years #}
-          {# if there is a yearRange, it supercedes the date ranges #}
-          {% if request.GET.yearRange %}
-            <input type="hidden" name="yearRange" value="{{query.yearRange}}" />
-          {% else %}
-            <input type="hidden" name="date1" value="{{query.date1}}" />
-            <input type="hidden" name="date2" value="{{query.date2}}" />
-          {% endif %}
-
-          {# All the chosen LCCNs #}
-          {% for lccn in titles %}
-            <input type="hidden" name="lccn" value="{{lccn}}" />
-          {% endfor %}
-
-          {# miscellaneous filters #}
-          <input type="hidden" name="language" value="{{query.language}}" />
-          <input type="hidden" name="frequency" value="{{query.frequency}}" />
-          <input type="hidden" name="sequence" value="{{query.sequence}}" />
-          <input type="hidden" name="sort" value="{{query.sort}}" />
-          <input type="hidden" name="rows" value="{{query.rows}}" />
-        {% endblock search_page_pagination_hidden_filters %}
-
-        <input type="submit" class="submit" value="GO" />
-      </form>
-    </div>
     <div class="col-md-2"><!-- todo: fix this, list is missing template and it does not mark which you have chosen -->
       <!-- Gallery or List view -->
       {% ifequal view_type 'list' %}
@@ -295,5 +216,10 @@ Thumbnails
 
 </div>
 {% endblock search_results_box %}
-
+{% block bottom_nav %}
+  <div class="row bottom_nav">
+    {% search_pages_results_pagination %}
+    {% search_pages_results_page_jump %}
+  </div>
+{% endblock bottom_nav %}
 {% endblock subcontent %}

--- a/core/templates/search/search_pages_results_page_jump.html
+++ b/core/templates/search/search_pages_results_page_jump.html
@@ -1,0 +1,45 @@
+<div class="col-md-3">
+<!-- Jump to page -->
+  <form action="" method="GET" class="jumptopage">
+    <label for="jumptopage">Jump to page:</label>
+    <input class="std" type="text" id="jumptopage" name="page" value="" size="5" />
+
+    {% block search_page_pagination_hidden_filters %}
+      {#### Filter preservation ####}
+
+      {# search text #}
+      <input type="hidden" name="proxtext" value="{{query.proxtext}}" />
+      <input type="hidden" name="proxdistance" value="{{query.proxdistance}}" />
+      <input type="hidden" name="ortext" value="{{query.ortext}}" />
+      <input type="hidden" name="andtext" value="{{query.andtext}}" />
+      <input type="hidden" name="phrasetext" value="{{query.phrasetext}}" />
+
+      {# location #}
+      <input type="hidden" name="city" value="{{query.city}}" />
+      <input type="hidden" name="county" value="{{query.county}}" />
+
+      {# date range and years #}
+      {# if there is a yearRange, it supercedes the date ranges #}
+      {% if request.GET.yearRange %}
+        <input type="hidden" name="yearRange" value="{{query.yearRange}}" />
+      {% else %}
+        <input type="hidden" name="date1" value="{{query.date1}}" />
+        <input type="hidden" name="date2" value="{{query.date2}}" />
+      {% endif %}
+
+      {# All the chosen LCCNs #}
+      {% for lccn in titles %}
+        <input type="hidden" name="lccn" value="{{lccn}}" />
+      {% endfor %}
+
+      {# miscellaneous filters #}
+      <input type="hidden" name="language" value="{{query.language}}" />
+      <input type="hidden" name="frequency" value="{{query.frequency}}" />
+      <input type="hidden" name="sequence" value="{{query.sequence}}" />
+      <input type="hidden" name="sort" value="{{query.sort}}" />
+      <input type="hidden" name="rows" value="{{query.rows}}" />
+    {% endblock search_page_pagination_hidden_filters %}
+
+    <input type="submit" class="submit" value="GO" />
+  </form>
+</div>

--- a/core/templates/search/search_pages_results_pagination.html
+++ b/core/templates/search/search_pages_results_pagination.html
@@ -1,0 +1,34 @@
+  <div class="col-md-7">
+    <!-- Pagination -->
+    <nav aria-label="Pages">
+      <ul class="pagination pagination-sm">
+{% if page.has_previous %}
+        <li><a href="{{previous_url}}" aria-label="Previous Page"><span aria-hidden="true">&laquo;</span></a></li>
+{% else %}
+        <li class="disabled"><span aria-hidden="true">&laquo;</span></li>
+{% endif %}
+
+{% for page_number in page_range_short %}
+  {% ifequal page_number "..." %}
+        <li class="disabled"><a>…</a></li>
+  {% else %}
+    {% ifequal page_number page.number %}
+        <li class="active" aria-current="true">
+    {% else %}
+        <li>
+    {% endifequal %}
+          <a href="?{{q}}&amp;page={{page_number}}&amp;sort={{sort}}" aria-label="Page {{page_number}}">{{page_number}}</a>
+        </li>
+  {% endifequal %}
+{% endfor %}
+
+{% if page.has_next %}
+        <li><a href="{{next_url}}" aria-label="Next Page"><span aria-hidden="true">&raquo;</span></a></li>
+{% else %}
+        <li class="disabled"><span aria-hidden="true">&raquo;</span></li>
+{% endif %}
+      </ul>
+    </nav>
+  <!-- /pagination -->
+  </div>
+

--- a/core/templatetags/custom_tags.py
+++ b/core/templatetags/custom_tags.py
@@ -24,3 +24,11 @@ def remove_param_value(context, key, value):
             params.setlist(key, args)
 
     return params.urlencode()
+
+@register.inclusion_tag('search/search_pages_results_pagination.html', takes_context=True)
+def search_pages_results_pagination(context):
+    return context
+
+@register.inclusion_tag('search/search_pages_results_page_jump.html', takes_context=True)
+def search_pages_results_page_jump(context):
+    return context


### PR DESCRIPTION
this pulls out the page nav and page jump sections from the search_pages_results template into their own templates; then they are added back in at the top and bottom as inclusion tags. Currently, the nav and jump functions are at the top only. Per Andrew Gearhart's comment, the gallery/list option is not duplicated at the bottom.