### PR TITLE
Fix typo in Alias path for non-Docker Apache

### DIFF
--- a/conf/apache/django.conf
+++ b/conf/apache/django.conf
@@ -10,7 +10,7 @@ LogLevel info
 # Document Root / Static Files
 DocumentRoot "/opt/openoni/static"
 AliasMatch ^/robots.txt$ /opt/openoni/static/robots.txt
-AliasMatch ^/sitemap.xml$ /opt/openoni/static/sitmaps/sitemap.xml
+AliasMatch ^/sitemap.xml$ /opt/openoni/static/sitemaps/sitemap.xml
 <Directory /opt/openoni/static>
     Require all granted
 </Directory>


### PR DESCRIPTION
@jduss4 spotted this