### PR TITLE
Feature/mariadb upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,12 +42,15 @@ Markdown Spec](https://github.github.com/gfm/).
 - `SOLR` setting now derived in `core/apps.py` [initialization
   customization](https://docs.djangoproject.com/en/2.2/ref/applications/#django.apps.AppConfig.ready)
   from user-facing `SOLR_BASE_URL` setting
+- Upgraded to MariaDB 10.4 for docker-compose users
 
 ### Removed
 - Solr configuration files have been removed, as mentioned in the "Changed"
   section
 
 ### Migration
+- If you're using docker, upgrade your MariaDB database:
+  - `docker-compose exec rdbms mysql_upgrade -p123456`
 - If you're using docker, rebuild your ONI image: `docker-compose build`
 - Docker developers will need to destroy all test volumes and the local test
   docker image or tests will not pass:

--- a/conf/mysql/openoni.cnf
+++ b/conf/mysql/openoni.cnf
@@ -70,7 +70,6 @@ innodb_log_files_in_group       = 2
 innodb_max_dirty_pages_pct      = 75
 innodb_max_purge_lag            = 0
 innodb_strict_mode              = 1
-innodb_support_xa               = 1
 sync_binlog                     = 1
 
 # Memory

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
   rdbms:
-    image: mariadb:5.5
+    image: mariadb:10.4
     environment:
       - MYSQL_ROOT_PASSWORD=123456
       - MYSQL_DATABASE=openoni

--- a/docker/_startup_lib.sh
+++ b/docker/_startup_lib.sh
@@ -18,7 +18,7 @@ verify_config() {
 
 setup_database() {
   DB_READY=0
-  MAX_TRIES=15
+  MAX_TRIES=30
   TRIES=0
   while [ $DB_READY == 0 ]
     do

--- a/test-compose.yml
+++ b/test-compose.yml
@@ -5,7 +5,7 @@ volumes:
 
 services:
   rdbms:
-    image: mariadb:5.5
+    image: mariadb:10.4
     environment:
       - MYSQL_ROOT_PASSWORD=123456
       - MYSQL_DATABASE=openoni


### PR DESCRIPTION
Upgrades the docker-compose stack to MariaDB 10.4

This should come after PR #451; for my own sanity when testing, I created this on top of the solr branch