### PR TITLE
Docker Apache config cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Markdown Spec](https://github.github.com/gfm/).
   - Retain `skiplink` class for backwards-compatibility and customization
 - Page reindexer no longer deletes pages prior to reindexing them, to avoid
   downtime when reindexing large sites
+- Clean up Docker Apache config
 
 ### Removed
 - `core/utils/__init__.py`, which overrode `strftime` with

--- a/conf/apache/django.conf
+++ b/conf/apache/django.conf
@@ -32,8 +32,7 @@ Alias /data/ /opt/openoni/data/
 </Directory>
 
 # Word Coordinate Files
-RewriteEngine on
-RewriteRule ^/lccn/(.*)/coordinates/$ /opt/openoni/data/word_coordinates/lccn/$1/coordinates.json.gz [L]
+AliasMatch ^/lccn/(.*)/coordinates/$ /opt/openoni/data/word_coordinates/lccn/$1/coordinates.json.gz
 
 # Inform browser coordinates files are gzipped JSON, not raw gzip files
 AddEncoding x-gzip .gz

--- a/docker/apache/openoni.conf
+++ b/docker/apache/openoni.conf
@@ -51,7 +51,12 @@ WSGIScriptAlias / /opt/openoni/onisite/wsgi.py
   </Files>
 </Directory>
 
-WSGIDaemonProcess openoni-wsgi-app display-name=openoni-wsgi-app maximum-requests=1 python-eggs=/opt/openoni/.python-eggs python-home=/opt/openoni/ENV python-path=/opt/openoni:/opt/openoni/ENV/lib/python3.6/site-packages
+# Development (Reload app every 5 requests per process)
+WSGIDaemonProcess openoni-wsgi-app display-name=openoni-wsgi-app maximum-requests=5 python-eggs=/opt/openoni/.python-eggs python-home=/opt/openoni/ENV python-path=/opt/openoni:/opt/openoni/ENV/lib/python3.6/site-packages
+
+# Production example (Create multiple processes; Reload every 10k requests)
+#WSGIDaemonProcess openoni-wsgi-app display-name=openoni-wsgi-app maximum-requests=10000 processes=8 python-eggs=/opt/openoni/.python-eggs python-home=/opt/openoni/ENV python-path=/opt/openoni:/opt/openoni/ENV/lib/python3.6/site-packages
+
 WSGIProcessGroup openoni-wsgi-app
 WSGISocketPrefix /var/run
 

--- a/docker/apache/openoni.conf
+++ b/docker/apache/openoni.conf
@@ -1,107 +1,62 @@
-WSGIScriptAlias / /opt/openoni/onisite/wsgi.py
-WSGIPythonPath /opt/openoni:/opt/openoni/ENV/lib/python3.6/site-packages
-WSGIPythonHome /opt/openoni/ENV
-
-WSGISocketPrefix /var/run
-WSGIDaemonProcess openoni-wsgi-app maximum-requests=1 python-eggs=/opt/openoni/.python-eggs display-name=openoni-wsgi-app
-
-WSGIProcessGroup openoni-wsgi-app
-
-#ServerAdmin you@example.com
-#ServerName localhost
-
-RewriteEngine  on
-
-RewriteRule ^/share/(.*) http://loc.gov/share/$1 [P] 
-
-RewriteRule ^/data/(.+)/(.+)sample(.+) - [F]
-
-RewriteRule ^/lccn/(.*)/coordinates/$ /opt/openoni/data/word_coordinates/lccn/$1/coordinates.json.gz [L]
-
-#
-# DocumentRoot: The directory out of which you will serve your
-# documents. By default, all requests are taken from this directory, but
-# symbolic links and aliases may be used to point to other locations.
-#
-DocumentRoot "/opt/openoni/static"
-
-AliasMatch ^/data/(.+) /opt/openoni/data/$1
-AliasMatch ^/data/ /opt/openoni/data/
-AliasMatch ^/robots.txt$ /opt/openoni/static/robots.txt
-AliasMatch ^/sitemap.xml$ /opt/openoni/static/sitemaps/sitemap.xml
-AliasMatch ^/(sitemap-\d+.xml)$ /opt/openoni/static/sitemaps/$1
-
-# This isn't necessary in production, though it shouldn't really hurt anything
-# if left in
-AliasMatch ^/coverage(.*)$ /opt/openoni/static/cov/$1
-
+## DJANGO
+# Django logging outputs to INFO level
 LogLevel !LOGLEVEL!
 
-# RAIS IIIF URLs
-AllowEncodedSlashes NoDecode
-ProxyPassMatch ^/(images/iiif/.*(?:\.jpg|info\.json))$ http://rais:12415/$1 nocanon
-
-#
-# Each directory to which Apache has access can be configured with respect
-# to which services and features are allowed and/or disabled in that
-# directory (and its subdirectories). 
-#
-# First, we configure the "default" to be a very restrictive set of 
-# features.  
-#
-<Directory />
-    Options Indexes FollowSymLinks
-    AllowOverride All
-    Order allow,deny
-    Allow from all
-    Require all granted
+# Reset permissions for Open ONI files
+<Directory /opt/openoni>
+    AllowOverride None
+    Options None
+    Require all denied
 </Directory>
 
-#
-# Note that from this point forward you must specifically allow
-# particular features to be enabled - so if something's not working as
-# you might expect, make sure that you have specifically enabled it
-# below.
-#
+# Document Root / Static Files
+DocumentRoot "/opt/openoni/static"
+AliasMatch ^/coverage/(.*)$ /opt/openoni/static/cov/$1
+AliasMatch ^/robots.txt$ /opt/openoni/static/robots.txt
+AliasMatch ^/sitemap.xml$ /opt/openoni/static/sitemaps/sitemap.xml
 <Directory /opt/openoni/static>
-    ExpiresActive On
-    ExpiresDefault A86400
-
-    Options Indexes FollowSymLinks
-    AllowOverride All
-
-    Order allow,deny
-    Allow from all
     Require all granted
 </Directory>
 
+# Compiled Static Files - manage.py collectstatic
+AliasMatch ^/favicon.ico$ /opt/openoni/static/compiled/images/favicon.ico
+AliasMatch ^/static/(.*)$ /opt/openoni/static/compiled/$1
+AliasMatch ^/(sitemap-\d+.xml)$ /opt/openoni/static/sitemaps/$1
+<Directory /opt/openoni/static/compiled>
+    Require all granted
+</Directory>
+
+# Data Files
+Alias /data/ /opt/openoni/data/
 <Directory /opt/openoni/data>
     Options Indexes FollowSymLinks
-    Allow from all
+
+    Require all granted
 </Directory>
 
-AliasMatch ^/static/(.*)$ /opt/openoni/static/compiled/$1
+# Word Coordinate Files
+AliasMatch ^/lccn/(.*)/coordinates/$ /opt/openoni/data/word_coordinates/lccn/$1/coordinates.json.gz
 
-<Directory /opt/openoni/static/compiled>
-    ExpiresActive On
-    ExpiresDefault A31536000
+# Inform browser coordinates files are gzipped JSON, not raw gzip files
+AddEncoding x-gzip .gz
+<FilesMatch .*\.json.gz>
+    ForceType application/json
+</FilesMatch>
 
-    AllowOverride None
-
-    Order allow,deny
-    Allow from all
-</Directory>
-
+# WSGI Django Application
+WSGIScriptAlias / /opt/openoni/onisite/wsgi.py
 <Directory /opt/openoni/onisite>
   <Files wsgi.py>
-    Order deny,allow
     Require all granted
   </Files>
 </Directory>
 
-# Inform browser our coordinates files are gzipped JSON, not raw gzip files
-AddEncoding x-gzip .gz
-<FilesMatch .*\.json.gz>
-  ForceType application/json
-</FilesMatch>
+WSGIDaemonProcess openoni-wsgi-app display-name=openoni-wsgi-app maximum-requests=1 python-eggs=/opt/openoni/.python-eggs python-home=/opt/openoni/ENV python-path=/opt/openoni:/opt/openoni/ENV/lib/python3.6/site-packages
+WSGIProcessGroup openoni-wsgi-app
+WSGISocketPrefix /var/run
 
+
+
+## RAIS
+AllowEncodedSlashes NoDecode
+ProxyPassMatch ^/(images/iiif/.*(?:\.jpg|info\.json))$ http://rais:12415/$1 nocanon


### PR DESCRIPTION
Change of possible note, `*share*` files in `/data/` are no longer denied. This seems like something that doesn't matter for development Docker environment, and otherwise would be institution-specific as I'm unaware of any NDNP or other standard use of such naming in data files.

Closes #464 