### PR TITLE
#517 Enables the SSL module in apache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Markdown Spec](https://github.github.com/gfm/).
 -->
 
 ## [Unreleased] - Brief description
-[Unreleased]: https://github.com/open-oni/open-oni/compare/v1.0.1...dev
+[Unreleased]: https://github.com/open-oni/open-oni/compare/v#.#.#...dev
 
 ### Fixed
 
@@ -43,6 +43,15 @@ Markdown Spec](https://github.github.com/gfm/).
 ### Deprecated
 
 ### Contributors
+
+## [Unreleased] - Enabled apache mod_ssl
+[Unreleased]: https://github.com/open-oni/open-oni/compare/v#.#.#...dev
+
+### Added
+ - Enabled apache mod_ssl in web image build
+
+### Contributors
+ - Jim Campbell (lauterman)
 
 ## [v1.0.1] - Changelog fixes
 [v1.0.1]: https://github.com/open-oni/open-oni/compare/v1.0.0...v1.0.1
@@ -801,4 +810,3 @@ bugs only discovered when there were multiple pages of batches
 
 This is the official initial release of Open ONI. The changes since forking are
 too numerous to try and describe.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,18 @@ Markdown Spec](https://github.github.com/gfm/).
 ## [Unreleased] - Enabled apache mod_ssl
 [Unreleased]: https://github.com/open-oni/open-oni/compare/v#.#.#...dev
 
+### Fixed
+
 ### Added
  - Enabled apache mod_ssl in web image build
+
+### Changed
+
+### Removed
+
+### Migration
+
+### Deprecated
 
 ### Contributors
  - Jim Campbell (lauterman)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,23 +27,6 @@ Markdown Spec](https://github.github.com/gfm/).
 ### Contributors
 -->
 
-## [Unreleased] - Brief description
-[Unreleased]: https://github.com/open-oni/open-oni/compare/v#.#.#...dev
-
-### Fixed
-
-### Added
-
-### Changed
-
-### Removed
-
-### Migration
-
-### Deprecated
-
-### Contributors
-
 ## [Unreleased] - Enabled apache mod_ssl
 [Unreleased]: https://github.com/open-oni/open-oni/compare/v#.#.#...dev
 

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -21,7 +21,7 @@ RUN apt-get update && \
 # Force apache error logs to stderr
 RUN ln -sf /proc/self/fd/1 /var/log/apache2/error.log
 
-RUN a2enmod cache cache_disk expires rewrite proxy_http
+RUN a2enmod cache cache_disk expires rewrite proxy_http ssl
 RUN mkdir -p /var/cache/httpd/mod_disk_cache
 RUN chown -R www-data:www-data /var/cache/httpd
 RUN a2dissite 000-default.conf


### PR DESCRIPTION
Enables apache mod_ssl, which then can be used by a custom configuration file.

- [ X] Verify all tests pass

onitest_test_1 exited with code 0

