### PR TITLE
Trial of a more standalone container setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 open-oni/
 data
 .git/
+ENV

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,13 +26,23 @@ services:
       - RAIS_TILEPATH=/opt/openoni/data/batches
     volumes:
       # Image files must be available at RAIS_TILEPATH
-      - ./data/batches:/opt/openoni/data/batches:z
+      - oni-data:/opt/openoni/data
   web:
     build:
-      context: ./docker
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: ./docker/Dockerfile
     volumes:
-      - ./:/opt/openoni:z
+      - oni-data:/opt/openoni/data
+      - oni-env:/opt/openoni/ENV
+      - ./core:/opt/openoni/core
+      - ./manage.py:/opt/openoni/manage.py
+      - ./onisite:/opt/openoni/onisite
+      - ./requirements.lock:/opt/openoni/requirements.lock
+      - ./requirements.pip:/opt/openoni/requirements.pip
+      - ./static:/opt/openoni/static
+      - ./themes:/opt/openoni/themes
+      - ./docker:/opt/openoni/docker
+      - ./log:/opt/openoni/log
     ports:
       - ${HTTPPORT:-80}:80
     depends_on:
@@ -60,3 +70,5 @@ services:
 volumes:
   data-mariadb: {}
   data-solr: {}
+  oni-env: {}
+  oni-data: {}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,9 +28,17 @@ RUN a2dissite 000-default.conf
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 WORKDIR /opt/openoni
-ADD . /opt/openoni
+ADD ./core /opt/openoni/core
+ADD ./manage.py /opt/openoni/manage.py
+ADD ./onisite /opt/openoni/onisite
+ADD ./requirements.lock /opt/openoni/requirements.lock
+ADD ./requirements.pip /opt/openoni/requirements.pip
+ADD ./static /opt/openoni/static
+ADD ./themes /opt/openoni/themes
+ADD ./docker /opt/openoni/docker
+RUN mkdir /opt/openoni/log
 
-ADD entrypoint.sh /
+ADD ./docker/entrypoint.sh /
 RUN chmod u+x /entrypoint.sh
 
 RUN echo "/usr/local/bin/manage delete_cache" > /etc/cron.daily/delete_cache


### PR DESCRIPTION
This is not a PR meant to actually merge, as I don't think it's a good idea.  It's more a way to make us think about how to handle the needs of developers separately from the needs of adopters.

This steals a lot of what's currently in PR #527, but puts things into the docker image piecemeal instead of all at once.  The underlying thoughts I had here:

- Our base image shouldn't include `ENV` in it, otherwise getting `ENV` rebuilt from scratch is difficult compared to just frying a volume
- We shouldn't be mounting in the whole dir in dev - the `ENV` dir has been especially annoying as we have to `sudo rm ENV -rf` to "refresh" our pip install.
- As much as possible, we want things that are mounted into the container to be very development-specific so that a production image "just works" but can still easily be the basis for development
- Eventually a setup like this reduces the split between CI, prod, and dev; we just define a "ci" service that doesn't mount things in, and do `docker-compose run ci test.sh` or something.  All the core stuff remains the same, and we don't need custom startup scripts or weird logic like we have today.

I don't think I've achieved anything of note here, just trying to think about unification of our docker setup.  may be best to just look this over, file it in the "jechols is still nuts" bucket, and move on....