### PR TITLE
Pin RAIS image to 3 instead of "latest"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - solr-precreate
       - openoni
   rais:
-    image: uolibraries/rais
+    image: uolibraries/rais:3
     environment:
       - RAIS_IIIFURL=${ONI_IIIF_URL:-http://localhost/images/iiif}
       - RAIS_TILECACHELEN=250


### PR DESCRIPTION
Because the installation variant via Docker gets used more often in production, use a fixed version instead of "latest".
For releases a pin to a minor might be favorable!

- List changes with brief descriptions
  - Pins RAIS image to major version 3

## Submitter Checklist

- [x ] Verify all tests pass
  - Run tests with `docker-compose -f test-compose.yml -p onitest up test`
"
...
test_1   | Ran 60 tests in 6.072s
test_1   | 
test_1   | OK
test_1   | Preserving test database for alias 'default'...
onitest_test_1 exited with code 0
"

- Update `CHANGELOG.md`
  - [ ] Describe change(s) in appropriate section(s) <-- BR: necessary for this?
  - [ ] List self in Contributors section <-- BR: not necessary, trivial change, maybe next time


## Reviewer Checklist

- [ ] Verify all tests pass
- [ ] Review changes for behavior, bugs, and compliance with [Development
  Standards](https://github.com/open-oni/open-oni/tree/dev/CONTRIBUTING.md#development-standards)
  - Request the submitter make any changes rather than pushing changes yourself.
    Otherwise ask another reviewer to look at any changes you have made.
- [ ] If a release, follow the [Release
  Checklist](https://github.com/open-oni/open-oni/tree/dev/CONTRIBUTING.md#release-checklist)
<!-- Markdown renders in unwanted carriage return if this text is continued on
     the next line, so breaking character margin intentionally here -->
