### PR TITLE
Feature/remove hidden search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Markdown Spec](https://github.github.com/gfm/).
  - Moved Dockerfile-dev to Dockerfile to support automated builds
 
 ### Removed
+ - Hidden input fields in search forms with search type and row count
 
 ### Migration
 
@@ -50,6 +51,7 @@ Markdown Spec](https://github.github.com/gfm/).
 
 ### Contributors
  - Jim Campbell (lauterman)
+ - Jessica Dussault (jduss4)
  - Andrew Gearhart (andrewgearhart)
  - Jeremy Echols (jechols)
 

--- a/core/templates/__base.html
+++ b/core/templates/__base.html
@@ -133,10 +133,6 @@
                   action="{% url 'openoni_search_pages_results' %}" role="search">
                   <div class="form-group">
                     {{ city_form.city }}
-                    <input type="hidden" name="rows" id="rows" alt="rows"
-                      value="20">
-                    <input type="hidden" name="searchType" alt="searchType"
-                      value="basic">
                     <input class="form-control" type="text" name="proxtext" aria-label="Search words"
                       placeholder="search words">
                   </div>

--- a/core/templates/search/search_advanced.html
+++ b/core/templates/search/search_advanced.html
@@ -151,8 +151,6 @@
         {% endcomment %}
         
         <div class="row">
-            <input type="hidden" name="rows" id="rows" value="20" />
-            <input type="hidden" name="searchType" value="advanced" />
             <div class="form-actions">
                 <button id="adv_reset" type="reset" value="clear" class="btn btn-link">Clear</button>
                 <button type="submit" value="Submit" class="btn btn-primary">Search</button>


### PR DESCRIPTION
searchType does not seem to be used
rows has a default value of 20 already in the search view

## Submitter Checklist

- [x] Verify all tests pass
  - Run tests with `docker-compose -f test-compose.yml -p onitest up test`
- [x] Update `README.md` and `docs/` as necessary
  - [x] If a `manage.py` command is added, deleted, or modified its help text must
    be valid and it should be documented in detail in
    `docs/advanced/admin-commands.md`
- Update `CHANGELOG.md`
  - [x] Describe change(s) in appropriate section(s)
  - [x] List self in Contributors section
- [x] @mention individual(s) you would like to review the PR
  - Reviews for releases must come from a reviewer at another institution

## Reviewer Checklist

- [x] Verify all tests pass
- [x] Review changes for behavior, bugs, and compliance with [Development
  Standards](https://github.com/open-oni/open-oni/tree/dev/CONTRIBUTING.md#development-standards)
  - Request the submitter make any changes rather than pushing changes yourself.
    Otherwise ask another reviewer to look at any changes you have made.

