### PR TITLE
Pin RAIS to 3.x in docker-compose setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Markdown Spec](https://github.github.com/gfm/).
 - Fixed poor alternative text on some thumbnails
 - Fixed accessibility issues with the global search form
 - Logging now works as expected
+- Pinned docker-compose users to RAIS 3.x to avoid breakages when 4.x ships
 
 ### Added
  - Enabled apache mod_ssl in web image build

--- a/docker-compose.override.yml-example
+++ b/docker-compose.override.yml-example
@@ -19,10 +19,6 @@ services:
       - 3306:3306
 
   rais:
-    # Uncomment this to pin to a specific major release of RAIS rather than
-    # just pulling the latest
-    #image: uolibraries/rais:3
-
     ports:
       # This exposes the RAIS image server locally.  This is rarely necessary,
       # even in development, but can be handy if the Apache rules don't seem to

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - solr-precreate
       - openoni
   rais:
-    image: uolibraries/rais
+    image: uolibraries/rais:3
     environment:
       - RAIS_IIIFURL=${ONI_IIIF_URL:-http://localhost/images/iiif}
       - RAIS_TILECACHELEN=250


### PR DESCRIPTION
Pins us to RAIS 3.x to avoid breakages when RAIS 4 emerges

## Submitter Checklist

- [x] Verify all tests pass
  - Run tests with `docker-compose -f test-compose.yml -p onitest up test`
- [x] Update `README.md` and `docs/` as necessary
  - [x] If a `manage.py` command is added, deleted, or modified its help text must
    be valid and it should be documented in detail in
    `docs/advanced/admin-commands.md`
- Update `CHANGELOG.md`
  - [x] Describe change(s) in appropriate section(s)
  - [x] List self in Contributors section
- If a release PR:
  - [x] In `CHANGELOG.md`, replace `[Unreleased]` with version and update compare link
  - [x] Update `core/version.py` with new version
- [x] Resolve merge conflicts
- [x] @mention individual(s) you would like to review the PR
  - Reviews for releases must come from a reviewer at another institution

## Reviewer Checklist

- [x] Verify all tests pass
- [x] Review changes for behavior, bugs, and compliance with [Development
  Standards](https://github.com/open-oni/open-oni/tree/dev/CONTRIBUTING.md#development-standards)
  - Request the submitter make any changes rather than pushing changes yourself.
    Otherwise ask another reviewer to look at any changes you have made.
- [ ] If a release, follow the [Release
  Checklist](https://github.com/open-oni/open-oni/tree/dev/CONTRIBUTING.md#release-checklist)
<!-- Markdown renders in unwanted carriage return if this text is continued on
     the next line, so breaking character margin intentionally here -->
