### PR TITLE
Isolate tests 100% from local dev's ENV/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@ Markdown Spec](https://github.github.com/gfm/).
 - Typo in CentOS RAIS docs for SELinux file context application command
 - Mistake in path for local settings copy command and outdated, non-general
   examples in CentOS OpenONI web app configuration documentation
-- Tests are properly isolated from the local environment
+- The test environment is now properly isolated from the local environment
+  (specifically the `ENV` directory)
 
 ### Added
  - Enabled apache mod_ssl in web image build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Markdown Spec](https://github.github.com/gfm/).
 - Typo in CentOS RAIS docs for SELinux file context application command
 - Mistake in path for local settings copy command and outdated, non-general
   examples in CentOS OpenONI web app configuration documentation
+- Tests are properly isolated from the local environment
 
 ### Added
  - Enabled apache mod_ssl in web image build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Markdown Spec](https://github.github.com/gfm/).
 - Mistake in path for local settings copy command and outdated, non-general
   examples in CentOS OpenONI web app configuration documentation
 - The test environment is now properly isolated from the local environment
-  (specifically the `ENV` directory)
+  (specifically the `ENV` directory, i.e., the Python virtual environment)
 
 ### Added
  - Enabled apache mod_ssl in web image build

--- a/docker/test-startup.sh
+++ b/docker/test-startup.sh
@@ -7,6 +7,7 @@ rsync -avq \
   --exclude="onisite/plugins/*" \
   --exclude="themes/*" \
   --exclude="log/*" \
+  --exclude="ENV/*" \
   /usr/local/src/openoni/ /opt/openoni
 cd /opt/openoni
 rsync -avq /usr/local/src/openoni/themes/default/ /opt/openoni/themes/default


### PR DESCRIPTION
This requires a rebuild of the test environment whenever volumes are
removed, but it ensures you can have an ENV locally from any crazy
project you're working on, switch to a branch somebody put in a PR for,
and still run that branch's environment for testing.

Partially addresses #535 

## Submitter Checklist

- [x] Verify all tests pass
  - Run tests with `docker-compose -f test-compose.yml -p onitest up test`
- [x] Update `README.md` and `docs/` as necessary
  - [x] If a `manage.py` command is added, deleted, or modified its help text must
    be valid and it should be documented in detail in
    `docs/advanced/admin-commands.md`
- Update `CHANGELOG.md`
  - [x] Describe change(s) in appropriate section(s)
  - [x] List self in Contributors section

## Reviewer Checklist

- [x] Verify all tests pass
- [x] Review changes for behavior, bugs, and compliance with [Development
  Standards](https://github.com/open-oni/open-oni/tree/dev/CONTRIBUTING.md#development-standards)
  - Request the submitter make any changes rather than pushing changes yourself.
    Otherwise ask another reviewer to look at any changes you have made.