### PR TITLE
Added 'Share' Button on Page View

### DIFF
--- a/core/templates/page.html
+++ b/core/templates/page.html
@@ -147,6 +147,11 @@
                 aria-hidden="true"></span>
               <a id="clip" href="#" target="print">Clip/Print Image</a>
             </span>
+          <span class="control">
+            <span class="glyphicon glyphicon-share"
+                  aria-hidden="true"></span>
+            <a id="share" href="{% url 'openoni_page' title.lccn issue.date_issued issue.edition page.sequence %}">Share</a>
+          </span>
           {% endif %}
         </span>{# /other_controls #}
       </div>{# /imageViewer_nav #}


### PR DESCRIPTION
- List changes with brief descriptions
  - Closes #397
@techgique 

Added 'Share' button on page view to link to page and remove highlighting. Unremarkable changes, so not adding myself to contributors, no `CHANGELOG.md` updates.

![Screen Shot 2020-10-25 at 11 20 41 AM](https://user-images.githubusercontent.com/15634295/97111263-40156380-16b4-11eb-92b6-999e7428adfb.png)

Following link:

![Screen Shot 2020-10-25 at 11 22 45 AM](https://user-images.githubusercontent.com/15634295/97111306-7a7f0080-16b4-11eb-9537-75d93b426f07.png)


## Submitter Checklist

- [X] Verify all tests pass
  - Run tests with `docker-compose -f test-compose.yml -p onitest up test`
- [X] Update `README.md` and `docs/` as necessary
  - [X] If a `manage.py` command is added, deleted, or modified its help text must
    be valid and it should be documented in detail in
    `docs/advanced/admin-commands.md`
- Update `CHANGELOG.md`
  - [X] Describe change(s) in appropriate section(s)
  - [X] List self in Contributors section
- If a release PR:
  - [X] In `CHANGELOG.md`, replace `[Unreleased]` with version and update compare link
  - [X] Update `core/version.py` with new version
- [X] Resolve merge conflicts
- [X] @mention individual(s) you would like to review the PR
  - Reviews for releases must come from a reviewer at another institution

## Reviewer Checklist

- [ ] Verify all tests pass
- [ ] Review changes for behavior, bugs, and compliance with [Development
  Standards](https://github.com/open-oni/open-oni/tree/dev/CONTRIBUTING.md#development-standards)
  - Request the submitter make any changes rather than pushing changes yourself.
    Otherwise ask another reviewer to look at any changes you have made.
- [ ] If a release, follow the [Release
  Checklist](https://github.com/open-oni/open-oni/tree/dev/CONTRIBUTING.md#release-checklist)
<!-- Markdown renders in unwanted carriage return if this text is continued on
     the next line, so breaking character margin intentionally here -->
