### PR TITLE
Feature/rolling public domain date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,9 @@ Markdown Spec](https://github.github.com/gfm/).
   - Skip creating wheels of packages that don't provide them on PyPI
   - Copy `pip-update.sh` into the web container for use in changing / updating
     Python dependencies and update `docs/advanced/docker-reference.md`
-- Public Domain rights statement now shows up under qualifying images (i.e.,
-  anything over 96 years ago)
+- Public Domain fixes: rights statements now show up under qualifying images,
+  and the date of a qualifying image is now rolling instead of static (96 years
+  ago, reset each January 1st)
 
 ### Added
 - Enabled apache mod_ssl in web image build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ Markdown Spec](https://github.github.com/gfm/).
   - Skip creating wheels of packages that don't provide them on PyPI
   - Copy `pip-update.sh` into the web container for use in changing / updating
     Python dependencies and update `docs/advanced/docker-reference.md`
+- Public Domain rights statement now shows up under qualifying images (i.e.,
+  anything over 96 years ago)
 
 ### Added
 - Enabled apache mod_ssl in web image build

--- a/core/models.py
+++ b/core/models.py
@@ -617,10 +617,12 @@ class Issue(models.Model):
 
     @property
     def copyright_link(self):
-        public_domain_date = datetime.date(1923,1,1)
+        # Starting recently, PD is a rolling date.  Each January 1st, it
+        # changes to 96 years prior to the current year.
+        public_domain_date = datetime.date(datetime.date.today().year - 96, 12, 31)
         public_domain_uri = 'http://creativecommons.org/publicdomain/mark/1.0/'
         public_domain_text = 'Public Domain Mark 1.0'
-        if self.date_issued < public_domain_date:
+        if self.date_issued <= public_domain_date:
             # A lot of times the PD record isn't in people's databases, so we
             # hack a PD record into the db on the fly
             copyright = Copyright.objects.filter(uri=public_domain_uri)

--- a/core/models.py
+++ b/core/models.py
@@ -618,11 +618,19 @@ class Issue(models.Model):
     @property
     def copyright_link(self):
         public_domain_date = datetime.date(1923,1,1)
-        public_domain_uri = "http://creativecommons.org/publicdomain/mark/1.0/"
+        public_domain_uri = 'http://creativecommons.org/publicdomain/mark/1.0/'
+        public_domain_text = 'Public Domain Mark 1.0'
+        if self.date_issued < public_domain_date:
+            # A lot of times the PD record isn't in people's databases, so we
+            # hack a PD record into the db on the fly
+            copyright = Copyright.objects.filter(uri=public_domain_uri)
+            if copyright.count() == 0:
+                c = Copyright(uri = public_domain_uri, label = public_domain_text)
+                c.save()
+                copyright = [c]
+            return copyright[0]
+
         try:
-            if self.date_issued < public_domain_date:
-                copyright = Copyright.objects.filter(uri=public_domain_uri)
-                return copyright[0]
             maps = LccnDateCopyright.objects.filter(lccn = self.title.lccn).filter(start_date__lt=self.date_issued).filter(end_date__gt=self.date_issued)
             if maps.exists():
                 return maps[0].copyright

--- a/core/tests/test_copyright.py
+++ b/core/tests/test_copyright.py
@@ -1,0 +1,46 @@
+from django.test import TestCase
+from core.models import Issue, Copyright
+import datetime
+
+class IssueCopyrightTests(TestCase):
+    # With no copyrights in the database, pulling a PD issue's link creates one
+    def test_empty_db_pd_issue_has_copyright_link(self):
+        self.assertEqual(Copyright.objects.count(), 0)
+        # This is the absolute latest an issue can be considered public domain
+        i = Issue(date_issued = datetime.date(datetime.date.today().year - 96, 12, 31))
+        c = i.copyright_link
+        self.assertEqual(Copyright.objects.count(), 1)
+        dbc = Copyright.objects.all()[0]
+
+        # Make sure what got stuffed in the DB is the same as what got returned
+        # since the return is created on the fly.
+        self.assertEqual(c.label, dbc.label)
+        self.assertEqual(c.uri, dbc.uri)
+
+        # Next we make sure label and URI aren't empty.  We don't hard-code the
+        # expected label/uri, we just want to be sure they exist.
+        self.assertTrue(len(c.label) > 10)
+        self.assertTrue(len(c.uri) > 10)
+
+    def test_non_pd_issue_has_no_copyright_link(self):
+        # This is the absolute earliest an issue can be non-PD
+        i = Issue(date_issued = datetime.date(datetime.date.today().year - 95, 1, 1))
+        c = i.copyright_link
+        # No copyright
+        self.assertTrue(c is None)
+        # No link is created in the db
+        self.assertEqual(Copyright.objects.count(), 0)
+
+    def test_we_dont_make_multiple_links(self):
+        self.assertEqual(Copyright.objects.count(), 0)
+        i1 = Issue(date_issued = datetime.date(1800, 1, 1))
+        c1 = i1.copyright_link
+        self.assertEqual(Copyright.objects.count(), 1)
+        dbc1 = Copyright.objects.all()[0]
+
+        i2 = Issue(date_issued = datetime.date(1801, 1, 1))
+        c2 = i2.copyright_link
+        self.assertEqual(Copyright.objects.count(), 1)
+
+        self.assertEqual(c1.uri, c2.uri)
+        self.assertEqual(c1.label, c2.label)


### PR DESCRIPTION
- Fixes public domain rights statements display
  - Closes #575 

## Submitter Checklist

- [x] Verify all tests pass
  - Run tests with `docker-compose -f test-compose.yml -p onitest up test`
- [x] Update `README.md` and `docs/` as necessary
  - [x] If a `manage.py` command is added, deleted, or modified its help text must
    be valid and it should be documented in detail in
    `docs/advanced/admin-commands.md`
- Update `CHANGELOG.md`
  - [x] Describe change(s) in appropriate section(s)
  - [x] List self in Contributors section
- If a release PR:
  - [x] In `CHANGELOG.md`, replace `[Unreleased]` with version and update compare link
  - [x] Update `core/version.py` with new version
- [x] Resolve merge conflicts
- [x] @mention individual(s) you would like to review the PR
  - Reviews for releases must come from a reviewer at another institution

## Reviewer Checklist

- [ ] Verify all tests pass
- [ ] Review changes for behavior, bugs, and compliance with [Development
  Standards](https://github.com/open-oni/open-oni/tree/dev/CONTRIBUTING.md#development-standards)
  - Request the submitter make any changes rather than pushing changes yourself.
    Otherwise ask another reviewer to look at any changes you have made.
- [ ] If a release, follow the [Release
  Checklist](https://github.com/open-oni/open-oni/tree/dev/CONTRIBUTING.md#release-checklist)
<!-- Markdown renders in unwanted carriage return if this text is continued on
     the next line, so breaking character margin intentionally here -->
